### PR TITLE
Remove migrate:up from Railway startCommand

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "buildCommand": "bun install && bun run build"
   },
   "deploy": {
-    "startCommand": "bun run migrate:up && bun run start",
+    "startCommand": "bun run start",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3
   }


### PR DESCRIPTION
Migrations run automatically on startup in main.ts, so no need to run the command in the start script.

This simplifies the Railway configuration and avoids duplicate migration runs on deploy.