### PR TITLE
feat: require all env vars, remove defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,15 @@
-# Needed for all environments
-# DATABASE_URL=postgresql://
-# CRYPTO_PEPPER=something-random
-# APP_URL=http://localhost
+# All variables are required
 
-# Optional: Set the expected origin for CSRF protection
-# If not set, will use request host as fallback
-# APP_ORIGIN=http://localhost:3000
+DATABASE_URL=postgresql://
+CRYPTO_PEPPER=something-random
+PORT=3000
+APP_NAME=Billet
+APP_URL=http://localhost:3000
 
-# Needed for .env.test only
-# CLAUDECODE=1
+# Email
+EMAIL_PROVIDER=console
+FROM_EMAIL=noreply@example.com
+FROM_NAME=Billet
+
+# Required when EMAIL_PROVIDER=resend
+# RESEND_API_KEY=re_your_key_here

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "billet",
+      "dependencies": {
+        "resend": "^6.9.4",
+      },
       "devDependencies": {
         "@biomejs/biome": "2.0.5",
         "@happy-dom/global-registrator": "^20.8.3",
@@ -15,6 +18,7 @@
         "preact": "^10.28.4",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "typescript": "^5.9.3",
       },
     },
   },
@@ -39,6 +43,8 @@
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.8.3" } }, "sha512-9z6lLr6K6dIFLiB9jI0tKTlYzCComn5RL7L1mN3EdMSCyRQB8I6A0FO/On8yYKkXuunexzPDC98zDflvv2wDrQ=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@types/bun": ["@types/bun@1.3.0", "", { "dependencies": { "bun-types": "1.3.0" } }, "sha512-+lAGCYjXjip2qY375xX/scJeVRmZ5cY0wyHYyCYxNcdEXrQ4AOe3gACgd4iQ8ksOslJtW4VNxBJ8llUwc3a6AA=="],
 
     "@types/node": ["@types/node@24.3.1", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g=="],
@@ -57,9 +63,13 @@
 
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
+
     "happy-dom": ["happy-dom@20.8.3", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ=="],
 
     "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
+
+    "postal-mime": ["postal-mime@2.7.3", "", {}, "sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw=="],
 
     "preact": ["preact@10.28.4", "", {}, "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ=="],
 
@@ -67,9 +77,19 @@
 
     "react-dom": ["react-dom@19.1.1", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.1" } }, "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw=="],
 
+    "resend": ["resend@6.9.4", "", { "dependencies": { "postal-mime": "2.7.3", "svix": "1.86.0" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-/M3dsJzu5OgozqVsA4Psd/1L7EdePgOIIxClas453GOQYFG3VHc2ZyCHZFlvqsc9aZCCd2BJRRqZgWC8D9c7/g=="],
+
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
+    "svix": ["svix@1.86.0", "", { "dependencies": { "standardwebhooks": "1.0.0", "uuid": "^10.0.0" } }, "sha512-/HTvXwjLJe1l/MsLXAO1ddCYxElJk4eNR4DzOjDOEmGrPN/3BtBE8perGwMAaJ2sT5T172VkBYzmHcjUfM1JRQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
     "undici-types": ["undici-types@7.10.0", "", {}, "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="],
+
+    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -34,9 +34,12 @@
     "@types/react-dom": "19.1.9",
     "happy-dom": "^20.8.3",
     "husky": "9.1.7",
-    "react": "^19.1.1",
     "preact": "^10.28.4",
+    "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "resend": "^6.9.4"
   }
 }

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -13,7 +13,7 @@ await seedIfEmpty();
 await initAssets();
 
 const server = Bun.serve({
-  port: process.env.PORT || 3000,
+  port: Number(process.env.PORT),
   idleTimeout: 30,
   routes: {
     ...appRoutes,

--- a/src/server/middleware/csrf.test.ts
+++ b/src/server/middleware/csrf.test.ts
@@ -11,6 +11,8 @@ import { csrfProtection } from "./csrf";
 if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL is required for tests");
 }
+
+const ORIGIN = new URL(process.env.APP_URL as string).origin;
 const connection = new SQL(process.env.DATABASE_URL);
 
 mock.module("../services/database", () => ({
@@ -37,7 +39,7 @@ describe("CSRF Middleware", () => {
 
   describe("csrfProtection", () => {
     test("allows GET requests without token", async () => {
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "GET",
       });
 
@@ -50,7 +52,7 @@ describe("CSRF Middleware", () => {
     });
 
     test("allows HEAD requests without token", async () => {
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "HEAD",
       });
 
@@ -63,7 +65,7 @@ describe("CSRF Middleware", () => {
     });
 
     test("allows OPTIONS requests without token", async () => {
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "OPTIONS",
       });
 
@@ -79,7 +81,7 @@ describe("CSRF Middleware", () => {
       const sessionId = await createTestSession();
       const cookieHeader = `session_id=${sessionId}`;
 
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "POST",
         headers: {
           Cookie: cookieHeader,
@@ -97,10 +99,10 @@ describe("CSRF Middleware", () => {
     });
 
     test("rejects POST request without session cookie", async () => {
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "POST",
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
         },
       });
 
@@ -118,10 +120,10 @@ describe("CSRF Middleware", () => {
       const sessionId = await createTestSession();
       const cookieHeader = `session_id=${sessionId}`;
 
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "POST",
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
           Cookie: cookieHeader,
         },
       });
@@ -141,10 +143,10 @@ describe("CSRF Middleware", () => {
       const cookieHeader = `session_id=${sessionId}`;
       const csrfToken = await createCsrfToken(sessionId, "POST", "/test");
 
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "POST",
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
           Cookie: cookieHeader,
           "X-CSRF-Token": csrfToken,
         },
@@ -167,10 +169,10 @@ describe("CSRF Middleware", () => {
       formData.append("_csrf", csrfToken);
       formData.append("other", "data");
 
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "POST",
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
           Cookie: cookieHeader,
         },
         body: formData,
@@ -188,10 +190,10 @@ describe("CSRF Middleware", () => {
       const sessionId = await createTestSession();
       const cookieHeader = `session_id=${sessionId}`;
 
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "POST",
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
           Cookie: cookieHeader,
           "X-CSRF-Token": "invalid.token",
         },
@@ -208,10 +210,10 @@ describe("CSRF Middleware", () => {
     });
 
     test("protects PUT requests", async () => {
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "PUT",
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
         },
       });
 
@@ -225,10 +227,10 @@ describe("CSRF Middleware", () => {
     });
 
     test("protects PATCH requests", async () => {
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "PATCH",
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
         },
       });
 
@@ -242,10 +244,10 @@ describe("CSRF Middleware", () => {
     });
 
     test("protects DELETE requests", async () => {
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "DELETE",
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
         },
       });
 
@@ -263,7 +265,7 @@ describe("CSRF Middleware", () => {
       const cookieHeader = `session_id=${sessionId}`;
       const csrfToken = await createCsrfToken(sessionId, "POST", "/test");
 
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "POST",
         headers: {
           Origin: "http://custom.com",
@@ -285,10 +287,10 @@ describe("CSRF Middleware", () => {
       const sessionId = await createTestSession();
       const cookieHeader = `session_id=${sessionId}`;
 
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "POST",
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
           Cookie: cookieHeader,
         },
       });
@@ -308,10 +310,10 @@ describe("CSRF Middleware", () => {
       const cookieHeader = `session_id=${sessionId}`;
       const csrfToken = await createCsrfToken(sessionId, "POST", "/test");
 
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "POST",
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
           Cookie: cookieHeader,
           "X-CSRF-Token": csrfToken,
         },
@@ -326,10 +328,10 @@ describe("CSRF Middleware", () => {
     });
 
     test("detects GET request method mismatch - returns 500 for configuration error", async () => {
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "GET",
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
         },
       });
 
@@ -350,10 +352,10 @@ describe("CSRF Middleware", () => {
       // Create token with actual request method
       const csrfToken = await createCsrfToken(sessionId, "PATCH", "/test");
 
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "PATCH",
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
           Cookie: cookieHeader,
           "X-CSRF-Token": csrfToken,
         },
@@ -374,10 +376,10 @@ describe("CSRF Middleware", () => {
       // Create token for PUT but make POST request
       const csrfToken = await createCsrfToken(sessionId, "PUT", "/test");
 
-      const req = createBunRequest("http://example.com/test", {
+      const req = createBunRequest(`${ORIGIN}/test`, {
         method: "POST", // Different method than token was created for
         headers: {
-          Origin: "http://example.com",
+          Origin: ORIGIN,
           Cookie: cookieHeader,
           "X-CSRF-Token": csrfToken,
         },

--- a/src/server/services/csrf.test.ts
+++ b/src/server/services/csrf.test.ts
@@ -336,19 +336,9 @@ describe("CSRF Service", () => {
       expect(isValid).toBe(false);
     });
 
-    test("uses request host as fallback when no expected origin provided", () => {
-      const req = new Request("http://example.com/test", {
-        headers: { Origin: "http://example.com" },
-      });
-
-      const isValid = validateOrigin(req);
-
-      expect(isValid).toBe(true);
-    });
-
-    test("uses APP_ORIGIN env var as fallback", () => {
-      const originalAppOrigin = process.env.APP_ORIGIN;
-      process.env.APP_ORIGIN = "http://test.com";
+    test("uses APP_URL env var when no expected origin provided", () => {
+      const originalAppUrl = process.env.APP_URL;
+      process.env.APP_URL = "http://test.com";
 
       const req = new Request("http://example.com/test", {
         headers: { Origin: "http://test.com" },
@@ -358,8 +348,7 @@ describe("CSRF Service", () => {
 
       expect(isValid).toBe(true);
 
-      // Restore original env
-      process.env.APP_ORIGIN = originalAppOrigin;
+      process.env.APP_URL = originalAppUrl;
     });
   });
 });

--- a/src/server/services/csrf.ts
+++ b/src/server/services/csrf.ts
@@ -201,11 +201,8 @@ export const validateOrigin = (
     const origin = req.headers.get("Origin");
     const referer = req.headers.get("Referer");
 
-    // Determine expected origin from env or request
     const expected =
-      expectedOrigin ||
-      process.env.APP_ORIGIN ||
-      `${new URL(req.url).protocol}//${new URL(req.url).host}`;
+      expectedOrigin || new URL(process.env.APP_URL as string).origin;
 
     if (origin) {
       return origin === expected;

--- a/src/server/services/email.ts
+++ b/src/server/services/email.ts
@@ -25,8 +25,8 @@ export class EmailService {
   constructor(private provider: EmailProvider) {}
 
   async sendMagicLink(data: MagicLinkEmailData): Promise<void> {
-    const fromEmail = process.env.FROM_EMAIL || "test@test.com";
-    const fromName = process.env.FROM_NAME || "Test";
+    const fromEmail = process.env.FROM_EMAIL as string;
+    const fromName = process.env.FROM_NAME as string;
 
     const message: EmailMessage = {
       to: data.to,
@@ -49,12 +49,12 @@ export class EmailService {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sign in to ${process.env.APP_NAME || "Test"}</title>
+  <title>Sign in to ${process.env.APP_NAME as string}</title>
 </head>
 <body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333;">
   <div style="max-width: 600px; margin: 0 auto; padding: 40px 20px;">
     <div style="text-align: center; margin-bottom: 40px;">
-      <h1 style="color: #2563eb; margin: 0;">${process.env.APP_NAME || "Test"}</h1>
+      <h1 style="color: #2563eb; margin: 0;">${process.env.APP_NAME as string}</h1>
     </div>
     
     <div style="background: #f8fafc; padding: 30px; border-radius: 8px; margin-bottom: 30px;">
@@ -66,7 +66,7 @@ export class EmailService {
       <div style="text-align: center; margin: 30px 0;">
         <a href="${data.magicLinkUrl}" 
            style="display: inline-block; background: #2563eb; color: white; text-decoration: none; padding: 12px 30px; border-radius: 6px; font-weight: 500;">
-          Sign in to ${process.env.APP_NAME || "Test"}
+          Sign in to ${process.env.APP_NAME as string}
         </a>
       </div>
       
@@ -85,7 +85,7 @@ export class EmailService {
   }
 
   private renderMagicLinkText(data: MagicLinkEmailData): string {
-    return `Sign in to ${process.env.APP_NAME || "Test"}
+    return `Sign in to ${process.env.APP_NAME as string}
 
 Click the link below to sign in to your account:
 ${data.magicLinkUrl}
@@ -104,6 +104,11 @@ const providerFactories: Record<string, () => EmailProvider> = {
       require("./email-providers/console") as typeof import("./email-providers/console");
     return new ConsoleLogProvider();
   },
+  resend: () => {
+    const { ResendProvider } =
+      require("./email-providers/resend") as typeof import("./email-providers/resend");
+    return new ResendProvider(process.env.RESEND_API_KEY as string);
+  },
 };
 
 export function registerEmailProvider(
@@ -115,7 +120,7 @@ export function registerEmailProvider(
 
 export const getEmailService = (): EmailService => {
   if (!emailServiceInstance) {
-    const providerName = process.env.EMAIL_PROVIDER || "console";
+    const providerName = process.env.EMAIL_PROVIDER as string;
     const factory = providerFactories[providerName];
 
     if (!factory) {

--- a/src/server/utils/env.ts
+++ b/src/server/utils/env.ts
@@ -1,33 +1,27 @@
 import { log } from "../services/logger";
 
-interface EnvConfig {
-  required: string[];
-  optional: string[];
-}
-
-const config: EnvConfig = {
-  required: ["DATABASE_URL", "CRYPTO_PEPPER"],
-  optional: ["PORT", "APP_NAME", "APP_ORIGIN", "FROM_EMAIL", "FROM_NAME"],
-};
+const REQUIRED = [
+  "DATABASE_URL",
+  "CRYPTO_PEPPER",
+  "PORT",
+  "APP_NAME",
+  "APP_URL",
+  "EMAIL_PROVIDER",
+  "FROM_EMAIL",
+  "FROM_NAME",
+];
 
 export function validateEnv(): void {
   const missing: string[] = [];
-  const warnings: string[] = [];
 
-  for (const key of config.required) {
+  for (const key of REQUIRED) {
     if (!process.env[key]) {
       missing.push(key);
     }
   }
 
-  for (const key of config.optional) {
-    if (!process.env[key]) {
-      warnings.push(key);
-    }
-  }
-
-  if (warnings.length > 0) {
-    log.warn("env", `Optional variables not set: ${warnings.join(", ")}`);
+  if (process.env.EMAIL_PROVIDER === "resend" && !process.env.RESEND_API_KEY) {
+    missing.push("RESEND_API_KEY");
   }
 
   if (missing.length > 0) {


### PR DESCRIPTION
## Summary
- All environment variables are now strictly required at startup — no silent fallback defaults anywhere in the app
- `validateEnv()` rewritten: single required list, conditional check for `RESEND_API_KEY` when `EMAIL_PROVIDER=resend`, no more optional/warning tier
- Stripped `|| ""`, `?? ""`, and `|| "http://localhost"` fallbacks from email service, CSRF, and server main
- Removed `APP_ORIGIN` env var — origin is now derived from `APP_URL` via `new URL().origin`
- Added resend email provider to factory map and installed `resend` package
- Updated `.env.example` with all required vars uncommented and documented
- Fixed CSRF tests to use `process.env.APP_URL` instead of hardcoded origins

## Test plan
- [ ] Verify `bun run check` passes (lint + typecheck)
- [ ] Verify server fails to start when required env vars are missing
- [ ] Verify CSRF tests pass with `APP_URL` set in test env
- [ ] Verify email provider selection works for both `console` and `resend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)