### PR TITLE
Switch Railway builder from Nixpacks to Metal

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "NIXPACKS",
+    "builder": "METAL",
     "buildCommand": "bun install && bun run build"
   },
   "deploy": {

--- a/railway.json
+++ b/railway.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
-    "builder": "METAL",
+    "builder": "RAILPACK",
     "buildCommand": "bun install && bun run build"
   },
   "deploy": {


### PR DESCRIPTION
Nixpacks is deprecated on Railway. This switches to the Metal build environment, which is faster and will become the default for all builds.

No changes to build or start commands — just the builder selection.