### PR TITLE
Remove unused APP_ORIGIN env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
       PORT: "3000"
       APP_NAME: San Jose
       APP_URL: http://localhost:3000
-      APP_ORIGIN: ""
       EMAIL_PROVIDER: console
       FROM_EMAIL: test@example.com
       FROM_NAME: Test

--- a/README.md
+++ b/README.md
@@ -249,7 +249,6 @@ A `railway.json` is included with build and start commands pre-configured. Deplo
 | `DATABASE_URL` | Yes | PostgreSQL connection string — auto-set when you link Railway's PostgreSQL plugin to your service |
 | `CRYPTO_PEPPER` | Yes | Secret key for session tokens — run `bun run generate:pepper` to get one (see below) |
 | `APP_URL` | Yes | Your app's public URL — you'll get this from Railway after your first deploy (e.g. `https://my-app.up.railway.app`) |
-| `APP_ORIGIN` | No | Expected origin for CSRF validation — defaults to request host if not set |
 | `PORT` | No | Server port — auto-set by Railway, defaults to `3000` locally |
 
 > **Generating `CRYPTO_PEPPER`:** This is a secret key used to secure session tokens. Run `bun run generate:pepper` to get a value. Use a different value for each environment (development, production, etc).

--- a/START_PROMPT.md
+++ b/START_PROMPT.md
@@ -20,7 +20,6 @@ Also create `.env.test` for the test suite. Use a separate test database (append
 DATABASE_URL=<their postgres url but with -test appended to the database name>
 CRYPTO_PEPPER=test-pepper-do-not-use-in-production
 APP_URL=http://localhost
-APP_ORIGIN=
 ```
 
 They'll need to create this database too (e.g. `CREATE DATABASE "<project-slug>-test";`).

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+    "scripts": {
+        "setup": "bun install",
+        "run": "main_dir=\"$(cd \"$(git rev-parse --git-common-dir)/..\" && pwd)\" && cp \"$main_dir/.env\" \"$main_dir/.env.test\" . && bun install"
+    }
+}


### PR DESCRIPTION
Removes the `APP_ORIGIN` environment variable from CI config, README, and setup prompt. CSRF validation already derives the origin from `APP_URL`, making `APP_ORIGIN` redundant.