### PR TITLE
Replace BrowserMCP reference with /browse skill in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file contains essential context and guidelines for Claude instances working
 **Key workflow reminders:**
 
 - Never try to run the local dev server. The Human is always running it in another tab on port 3000.
-- Always test your work with BrowserMCP to confirm it works as expected.
+- Always test your work with the /browse skill to confirm it works as expected.
 - This project uses JSX for it's template engine but it is NOT a React (client) project.
 - When trying different approaches for a given problem, always go back and remove or refactor.
 - Use code comments sparingly. Save them for when the extra context is really needed.


### PR DESCRIPTION
## Summary
- Updates the workflow reminder in CLAUDE.md to point to the `/browse` skill instead of the retired BrowserMCP tool.

## Test plan
- [x] Docs-only change; no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)