### PR TITLE
Make SESSION_COOKIE_NAME configurable to avoid localhost collisions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ PORT=3000
 APP_NAME=Billet
 APP_URL=http://localhost:3000
 
+# Optional — defaults to "session_id". Set a project-unique value when running
+# multiple billet apps on localhost so their cookies don't collide across ports.
+# SESSION_COOKIE_NAME=myapp_session
+
 # Email
 EMAIL_PROVIDER=console
 FROM_EMAIL=noreply@example.com

--- a/START_PROMPT.md
+++ b/START_PROMPT.md
@@ -19,6 +19,8 @@ FROM_NAME=<Project Name>
 
 > **Note:** `APP_URL` must include the port (`:3000`). CSRF origin validation compares the request `Origin` header against `APP_URL` and will reject form submissions if they don't match exactly.
 
+> **Tip:** If they're likely to run multiple billet apps on `localhost` at once (different ports), also set `SESSION_COOKIE_NAME=<project-slug>_session` in `.env`. Browsers scope cookies by hostname, not port, so the default `session_id` cookie collides across projects and they'll get logged out of one whenever they visit another.
+
 If they don't have a PostgreSQL database yet, tell them they can create one locally with `CREATE DATABASE "<project-slug>";` and their URL will look like `postgresql://user:password@localhost:5432/<project-slug>`. Or they can ask you to set one up for them.
 
 Also create `.env.test` for the test suite. Use a separate test database (append `-test` to the database name) to avoid interfering with development data:

--- a/src/server/services/sessions.ts
+++ b/src/server/services/sessions.ts
@@ -23,7 +23,8 @@ export interface SessionContext {
 const GUEST_EXPIRY_MS = 24 * 60 * 60 * 1000;
 const AUTH_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000;
 
-export const SESSION_COOKIE_NAME = "session_id";
+export const SESSION_COOKIE_NAME =
+  process.env.SESSION_COOKIE_NAME ?? "session_id";
 export const SESSION_COOKIE_OPTIONS = {
   httpOnly: true,
   secure: process.env.NODE_ENV === "production",


### PR DESCRIPTION
## Summary
- `SESSION_COOKIE_NAME` now reads from env (defaults to `session_id`), so multiple billet apps on different localhost ports can each use their own cookie name and avoid clobbering each other's sessions.
- Documents the new optional var in `.env.example` and adds a setup tip to `START_PROMPT.md` for projects likely to run alongside other billet apps.

## Test plan
- [x] `bun run check` passes (lint + typecheck)
- [x] `bun run test` — all 250 tests pass with `.env.test` pinned to `session_id`
- [ ] Set a unique `SESSION_COOKIE_NAME` in two billet projects on different ports and confirm sessions stay independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)