### PR TITLE
Fix page-lifecycle.test.ts CI hang on bun ≥1.3.14

### DIFF
--- a/src/client/page-lifecycle.test.ts
+++ b/src/client/page-lifecycle.test.ts
@@ -1,17 +1,20 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  cleanupCurrentPage,
+  initializePage,
+  registerPage,
+} from "./page-lifecycle";
 
 afterEach(() => {
-  // Re-import to get fresh module state each test
-  mock.module("./page-lifecycle", () => import("./page-lifecycle"));
+  // Reset the active-page state between tests. The module keeps its registry
+  // and current-page pointer at module scope, so clear the pointer here rather
+  // than re-importing the module (a self-referential mock.module factory busy-
+  // loops the resolver on some bun versions).
+  cleanupCurrentPage();
 });
 
-async function freshModule() {
-  return await import("./page-lifecycle");
-}
-
 describe("registerPage + initializePage", () => {
-  test("calls init on a registered page", async () => {
-    const { registerPage, initializePage } = await freshModule();
+  test("calls init on a registered page", () => {
     const init = mock(() => {});
     registerPage("dashboard", { init });
 
@@ -20,21 +23,17 @@ describe("registerPage + initializePage", () => {
     expect(init).toHaveBeenCalledTimes(1);
   });
 
-  test("does nothing for undefined page name", async () => {
-    const { initializePage } = await freshModule();
+  test("does nothing for undefined page name", () => {
     expect(() => initializePage(undefined)).not.toThrow();
   });
 
-  test("does nothing for unregistered page name", async () => {
-    const { initializePage } = await freshModule();
+  test("does nothing for unregistered page name", () => {
     expect(() => initializePage("nonexistent")).not.toThrow();
   });
 });
 
 describe("cleanupCurrentPage", () => {
-  test("calls cleanup on the current page", async () => {
-    const { registerPage, initializePage, cleanupCurrentPage } =
-      await freshModule();
+  test("calls cleanup on the current page", () => {
     const cleanup = mock(() => {});
     registerPage("dashboard", { init: () => {}, cleanup });
 
@@ -44,23 +43,18 @@ describe("cleanupCurrentPage", () => {
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
-  test("does nothing when no page is active", async () => {
-    const { cleanupCurrentPage } = await freshModule();
+  test("does nothing when no page is active", () => {
     expect(() => cleanupCurrentPage()).not.toThrow();
   });
 
-  test("does nothing when page has no cleanup", async () => {
-    const { registerPage, initializePage, cleanupCurrentPage } =
-      await freshModule();
+  test("does nothing when page has no cleanup", () => {
     registerPage("simple", { init: () => {} });
 
     initializePage("simple");
     expect(() => cleanupCurrentPage()).not.toThrow();
   });
 
-  test("clears current page after cleanup", async () => {
-    const { registerPage, initializePage, cleanupCurrentPage } =
-      await freshModule();
+  test("clears current page after cleanup", () => {
     const cleanup = mock(() => {});
     registerPage("dashboard", { init: () => {}, cleanup });
 

--- a/src/server/test-utils/run-tests.ts
+++ b/src/server/test-utils/run-tests.ts
@@ -19,9 +19,17 @@ for await (const file of glob.scan({ cwd: "src" })) {
 }
 files.sort();
 
+// Per-file timeout safety net: a hung file is killed, named, and counted as
+// failed instead of stalling the whole job for minutes. Override via env.
+const FILE_TIMEOUT_MS = Number.parseInt(
+  process.env.TEST_FILE_TIMEOUT_MS ?? "60000",
+  10,
+);
+
 let passed = 0;
 let failed = 0;
 const failedFiles: string[] = [];
+const timings: { file: string; ms: number }[] = [];
 
 for (const file of files) {
   const proc = Bun.spawn(["bun", "test", "--no-coverage", file], {
@@ -30,11 +38,21 @@ for (const file of files) {
     stderr: "pipe",
   });
 
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, FILE_TIMEOUT_MS);
+
+  const start = performance.now();
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
     proc.exited,
   ]);
+  clearTimeout(timer);
+  const ms = Math.round(performance.now() - start);
+  timings.push({ file, ms });
 
   const output = stdout + stderr;
   const passMatch = output.match(/(\d+) pass/);
@@ -44,16 +62,30 @@ for (const file of files) {
   passed += filePass;
   failed += fileFail;
 
-  if (exitCode !== 0) {
+  if (timedOut) {
+    failed += 1;
+    failedFiles.push(file);
+    console.log(
+      `\n${file} — TIMED OUT after ${Math.round(FILE_TIMEOUT_MS / 1000)}s — killed`,
+    );
+  } else if (exitCode !== 0) {
     failedFiles.push(file);
     console.log(`\n${file}`);
     console.log(output);
   } else {
-    console.log(`${file} (${filePass} tests)`);
+    console.log(`${file} (${filePass} tests, ${ms}ms)`);
   }
 }
 
 console.log(`\n${passed} pass, ${failed} fail across ${files.length} files`);
+
+const slowest = [...timings].sort((a, b) => b.ms - a.ms).slice(0, 10);
+if (slowest.length > 0) {
+  console.log("\nSlowest files:");
+  for (const { file, ms } of slowest) {
+    console.log(`  ${ms}ms  ${file}`);
+  }
+}
 
 if (failedFiles.length > 0) {
   console.log("\nFailed files:");


### PR DESCRIPTION
`src/client/page-lifecycle.test.ts` used a self-referential `mock.module` factory that re-imported the module under test, which busy-loops bun 1.3.14's resolver and turns the CI `test` job into an 8+ minute (effectively hung) run; this resets module state via the public `cleanupCurrentPage()` API instead, with no production code changes and all 7 tests preserved. It also adds per-file timing, a "slowest files" summary, and a per-file timeout (`TEST_FILE_TIMEOUT_MS`, default 60s) to `src/server/test-utils/run-tests.ts` so any future hang fails fast and diagnosably rather than stalling the job. Verified green on both bun 1.3.12 and the regressed 1.3.14 (the hung file now runs in ~77ms), with the full suite at 250 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)