### PR TITLE
Pin SESSION_COOKIE_NAME in test runner to prevent .env leakage

### DIFF
--- a/src/server/test-utils/run-tests.ts
+++ b/src/server/test-utils/run-tests.ts
@@ -33,7 +33,13 @@ const timings: { file: string; ms: number }[] = [];
 
 for (const file of files) {
   const proc = Bun.spawn(["bun", "test", "--no-coverage", file], {
-    env: { ...process.env, NODE_ENV: "test" },
+    // Pin the session cookie name: tests hardcode `session_id=`, so a custom
+    // SESSION_COOKIE_NAME in a developer's .env must not leak in and break them.
+    env: {
+      ...process.env,
+      NODE_ENV: "test",
+      SESSION_COOKIE_NAME: "session_id",
+    },
     stdout: "pipe",
     stderr: "pipe",
   });


### PR DESCRIPTION
Tests hardcode `session_id=` as the cookie name, but sessions.ts reads SESSION_COOKIE_NAME from env (configurable since #22). Bun auto-loads a developer's .env for NODE_ENV=test, so a custom SESSION_COOKIE_NAME there leaked into the suite and broke every authenticated/CSRF test.

Force SESSION_COOKIE_NAME=session_id in the per-file test spawn so runs are deterministic regardless of local .env or shell exports.