### PR TITLE
Harden Postgres pool + add Railway healthcheck

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -6,6 +6,8 @@
   },
   "deploy": {
     "startCommand": "bun run start",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 30,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3
   }

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -23,6 +23,13 @@ const server = Bun.serve({
   async fetch(req) {
     const url = new URL(req.url);
 
+    // Lightweight liveness check for the platform healthcheck. Intentionally
+    // does not touch the DB — a transient DB blip should not cause the host to
+    // cycle the instance.
+    if (url.pathname === "/health") {
+      return new Response("ok", { status: 200 });
+    }
+
     if (url.pathname.startsWith("/assets/")) {
       const cached = handleAssetRequest(url);
       if (cached) return cached;

--- a/src/server/services/database.ts
+++ b/src/server/services/database.ts
@@ -5,7 +5,24 @@ if (!process.env.DATABASE_URL) {
   throw new Error("DATABASE_URL is not set");
 }
 
-export const db = new SQL(process.env.DATABASE_URL);
+export const db = new SQL(process.env.DATABASE_URL, {
+  // Keep the pool healthy on hosts whose private network silently drops idle
+  // TCP connections (e.g. Railway). Recycle connections before they go stale so
+  // a request never gets handed a dead socket (the cause of hung requests that
+  // surface as upstream 502/499 errors).
+  max: 10,
+  idleTimeout: 20,
+  maxLifetime: 300,
+  connectionTimeout: 10,
+  onclose: (err) => {
+    if (!err) return;
+    // Idle-timeout and max-lifetime closes are the pool doing its job —
+    // recycling connections before the network drops them. Only surface
+    // genuinely unexpected closes (e.g. network resets).
+    if (/idle timeout|lifetime/i.test(err.message)) return;
+    log.warn("database", `Connection closed unexpectedly: ${err.message}`);
+  },
+});
 
 // Test database connection
 export const testConnection = async (): Promise<boolean> => {


### PR DESCRIPTION
Projects spun off billet inherit an untuned Bun SQL pool (`new SQL(DATABASE_URL)`). On hosts whose private network silently drops idle TCP connections (e.g. Railway), the pool ends up holding dead sockets; requests then hang on them until Bun's `idleTimeout` closes the HTTP connection, surfacing to clients as upstream 502 ("connection closed unexpectedly") and 499 errors. This was diagnosed and fixed in a downstream project; porting it up so every future project is born correct.

- Tune the pool (`idleTimeout`/`maxLifetime`/`connectionTimeout`/`max`) so connections recycle before the network kills them, and log only genuinely unexpected closes rather than routine idle/lifetime recycling.
- Add a DB-free `/health` endpoint and wire it as Railway's `healthcheckPath` so a truly-dead instance gets cycled instead of serving clients errors.

No behavior change for app routes; this is connection lifecycle + observability only. `bun run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)