### PR TITLE
Add canonical, per-page meta, theme-color, and SVG favicon to head

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <rect width="24" height="24" rx="5" fill="#0a0a0b" />
+  <g transform="translate(12 12) scale(0.72) translate(-12 -12)" fill="none" stroke="#ededef" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" />
+    <path d="m3.3 7 8.7 5 8.7-5" />
+    <path d="M12 22V12" />
+  </g>
+</svg>

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#0a0a0b","background_color":"#0a0a0b","display":"standalone"}

--- a/src/server/components/layouts.tsx
+++ b/src/server/components/layouts.tsx
@@ -9,12 +9,66 @@ const SITE_URL = "https://billet.alexprice.dev";
 const SITE_DESCRIPTION =
   "Full-stack TypeScript starter — designed to be built on by AI coding agents";
 
+// The site is dark-only (see `colorScheme: "dark"` on <html>), so theme-color
+// matches --color-bg from style.css rather than shipping light/dark variants.
+const THEME_COLOR = "#0a0a0b";
+
+const canonicalUrl = (path?: string): string =>
+  path ? new URL(path, SITE_URL).href : SITE_URL;
+
+interface HeadMetaProps {
+  title: string;
+  description: string;
+  canonicalPath?: string;
+}
+
+// Shared <head> essentials for both Layout and BaseLayout, so the two can't
+// drift out of sync (e.g. one missing the description or canonical tag).
+function HeadMeta({ title, description, canonicalPath }: HeadMetaProps) {
+  return (
+    <>
+      <meta charSet="utf-8" />
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1, viewport-fit=cover"
+      />
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <meta name="color-scheme" content="dark" />
+      <meta name="theme-color" content={THEME_COLOR} />
+      <link rel="canonical" href={canonicalUrl(canonicalPath)} />
+      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+      <link
+        rel="apple-touch-icon"
+        sizes="180x180"
+        href="/apple-touch-icon.png"
+      />
+      <link
+        rel="icon"
+        type="image/png"
+        sizes="32x32"
+        href="/favicon-32x32.png"
+      />
+      <link
+        rel="icon"
+        type="image/png"
+        sizes="16x16"
+        href="/favicon-16x16.png"
+      />
+      <link rel="manifest" href="/site.webmanifest" />
+      <link rel="stylesheet" href={getAssetUrl("/assets/main.css")} />
+    </>
+  );
+}
+
 interface LayoutProps {
   title: string;
   name: string;
   children: React.ReactNode;
   user?: User | null;
   csrfToken?: string;
+  description?: string;
+  canonicalPath?: string;
 }
 
 export function Layout({
@@ -23,45 +77,26 @@ export function Layout({
   children,
   user,
   csrfToken,
+  description = SITE_DESCRIPTION,
+  canonicalPath,
 }: LayoutProps) {
   return (
     <html lang="en" style={{ colorScheme: "dark" }}>
       <head>
-        <meta charSet="utf-8" />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1, viewport-fit=cover"
+        <HeadMeta
+          title={title}
+          description={description}
+          canonicalPath={canonicalPath}
         />
-        <title>{title}</title>
-        <meta name="description" content={SITE_DESCRIPTION} />
         <meta property="og:title" content={title} />
-        <meta property="og:description" content={SITE_DESCRIPTION} />
+        <meta property="og:description" content={description} />
         <meta property="og:image" content={`${SITE_URL}/og-image.png`} />
-        <meta property="og:url" content={SITE_URL} />
+        <meta property="og:url" content={canonicalUrl(canonicalPath)} />
         <meta property="og:type" content="website" />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={title} />
-        <meta name="twitter:description" content={SITE_DESCRIPTION} />
+        <meta name="twitter:description" content={description} />
         <meta name="twitter:image" content={`${SITE_URL}/og-image.png`} />
-        <link
-          rel="apple-touch-icon"
-          sizes="180x180"
-          href="/apple-touch-icon.png"
-        />
-        <link
-          rel="icon"
-          type="image/png"
-          sizes="32x32"
-          href="/favicon-32x32.png"
-        />
-        <link
-          rel="icon"
-          type="image/png"
-          sizes="16x16"
-          href="/favicon-16x16.png"
-        />
-        <link rel="manifest" href="/site.webmanifest" />
-        <link rel="stylesheet" href={getAssetUrl("/assets/main.css")} />
         <script
           type="importmap"
           dangerouslySetInnerHTML={{
@@ -106,37 +141,24 @@ export function Layout({
 interface BaseLayoutProps {
   title: string;
   children: React.ReactNode;
+  description?: string;
+  canonicalPath?: string;
 }
 
-export function BaseLayout({ title, children }: BaseLayoutProps) {
+export function BaseLayout({
+  title,
+  children,
+  description = SITE_DESCRIPTION,
+  canonicalPath,
+}: BaseLayoutProps) {
   return (
     <html lang="en" style={{ colorScheme: "dark" }}>
       <head>
-        <meta charSet="utf-8" />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1, viewport-fit=cover"
+        <HeadMeta
+          title={title}
+          description={description}
+          canonicalPath={canonicalPath}
         />
-        <title>{title}</title>
-        <link
-          rel="apple-touch-icon"
-          sizes="180x180"
-          href="/apple-touch-icon.png"
-        />
-        <link
-          rel="icon"
-          type="image/png"
-          sizes="32x32"
-          href="/favicon-32x32.png"
-        />
-        <link
-          rel="icon"
-          type="image/png"
-          sizes="16x16"
-          href="/favicon-16x16.png"
-        />
-        <link rel="manifest" href="/site.webmanifest" />
-        <link rel="stylesheet" href={getAssetUrl("/assets/main.css")} />
       </head>
       <body>{children}</body>
     </html>

--- a/src/server/templates/admin-dashboard.tsx
+++ b/src/server/templates/admin-dashboard.tsx
@@ -19,6 +19,8 @@ export const AdminDashboard = (props: {
 }) => (
   <Layout
     title="Admin"
+    description="Billet admin dashboard — role-protected routes and server-rendered views."
+    canonicalPath="/admin"
     name="admin"
     user={props.user}
     csrfToken={props.csrfToken}

--- a/src/server/templates/forms.tsx
+++ b/src/server/templates/forms.tsx
@@ -24,7 +24,14 @@ export const Forms = ({
   formCsrfToken,
   state,
 }: FormsProps) => (
-  <Layout title="Forms - Billet" name="forms" user={user} csrfToken={csrfToken}>
+  <Layout
+    title="Forms - Billet"
+    description="Server-rendered form patterns in Billet — CSRF protection, validation, and post-redirect-get flash messages."
+    canonicalPath="/forms"
+    name="forms"
+    user={user}
+    csrfToken={csrfToken}
+  >
     <h1>Form Patterns</h1>
     <p className="lead">
       Interactive forms with validation, CSRF protection, and flash messages

--- a/src/server/templates/home.tsx
+++ b/src/server/templates/home.tsx
@@ -9,6 +9,8 @@ interface HomeProps {
 export const Home = ({ user, csrfToken }: HomeProps) => (
   <Layout
     title="Billet — The AI-native TypeScript starter"
+    description="Full-stack TypeScript starter for AI coding agents — server-rendered JSX, custom CSS, and PostgreSQL via Bun in a single deploy target."
+    canonicalPath="/"
     name="home"
     user={user}
     csrfToken={csrfToken}

--- a/src/server/templates/login.tsx
+++ b/src/server/templates/login.tsx
@@ -14,7 +14,11 @@ export interface LoginProps {
 
 export const Login = ({ state }: LoginProps) => {
   return (
-    <BaseLayout title="Login - Billet">
+    <BaseLayout
+      title="Login - Billet"
+      description="Log in to Billet with a magic link — no passwords to remember."
+      canonicalPath="/login"
+    >
       <main className="login-page">
         <div className="login-wrapper">
           <div className="login-header">

--- a/src/server/templates/projects.tsx
+++ b/src/server/templates/projects.tsx
@@ -24,6 +24,8 @@ export const Projects = (props: ProjectsProps): JSX.Element => {
   return (
     <Layout
       title="CRUD - Billet"
+      description="Create, read, update, and delete records with server-rendered forms, CSRF protection, and flash messages."
+      canonicalPath="/projects"
       name="projects"
       user={props.user}
       csrfToken={props.csrfToken}

--- a/src/server/templates/stack.tsx
+++ b/src/server/templates/stack.tsx
@@ -8,7 +8,14 @@ interface StackProps {
 }
 
 export const Stack = ({ user, csrfToken }: StackProps) => (
-  <Layout title="Stack - Billet" name="stack" user={user} csrfToken={csrfToken}>
+  <Layout
+    title="Stack - Billet"
+    description="The Billet stack — Bun, server-rendered JSX, custom CSS, and PostgreSQL in one process with one test runner and one deploy target."
+    canonicalPath="/stack"
+    name="stack"
+    user={user}
+    csrfToken={csrfToken}
+  >
     <h1>The Stack</h1>
     <p className="lead">
       Billet is a server-rendered TypeScript starter built on Bun. Templates are


### PR DESCRIPTION
Audits the head against the specification.website Foundations checks and closes the gaps. Extracts a shared `HeadMeta` component so `Layout` and `BaseLayout` (login) can no longer drift out of sync. Adds canonical links, per-page meta descriptions that flow through to Open Graph and Twitter tags, `color-scheme` and `theme-color` meta, and an SVG favicon. Also fixes the webmanifest `theme_color`/`background_color`, which declared white while the site forces a dark scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)