### PR TITLE
Harden email deliverability: fix Resend replyTo/headers bug, add DNS runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,13 @@ APP_URL=http://localhost:3000
 
 # Email
 EMAIL_PROVIDER=console
+# Must be on a Resend-verified domain; prefer a monitored mailbox over noreply@
+# for engagement reputation. See runbooks/EMAIL.md for DNS/deliverability setup.
 FROM_EMAIL=noreply@example.com
 FROM_NAME=Billet
+
+# Optional — monitored address to receive replies when FROM_EMAIL is unmonitored.
+# REPLY_TO_EMAIL=support@yourdomain.com
 
 # Required when EMAIL_PROVIDER=resend
 # RESEND_API_KEY=re_your_key_here

--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ A `railway.json` is included with build and start commands pre-configured. Deplo
 
 > **Generating `CRYPTO_PEPPER`:** This is a secret key used to secure session tokens. Run `bun run generate:pepper` to get a value. Use a different value for each environment (development, production, etc).
 
+> **Email deliverability:** When sending real mail via Resend, follow [runbooks/EMAIL.md](runbooks/EMAIL.md) to set up SPF, DKIM, and DMARC — without it, magic links land in spam.
+
 ### Database
 
 Billet uses PostgreSQL through Bun's built-in `Bun.SQL` — no ORM, no driver dependency. Migrations run automatically on server startup — pending migrations are applied before the server accepts requests. If a migration fails, the server won't start (fail-safe).

--- a/runbooks/EMAIL.md
+++ b/runbooks/EMAIL.md
@@ -1,0 +1,81 @@
+# Email Deliverability Runbook
+
+Every email the app sends — the magic-link login being the built-in one — is
+transactional and goes through Resend. Landing in the inbox (not spam) depends
+almost entirely on DNS: SPF, DKIM, and DMARC. This runbook is domain-agnostic —
+replace `<your-domain>` with your real sending domain throughout.
+
+There are no marketing/bulk sends here, so List-Unsubscribe, BIMI, MTA-STS, and
+open/click tracking are intentionally out of scope (see [Non-goals](#5-non-goals)).
+
+## 1. Resend domain verification
+
+1. In the Resend dashboard, add `<your-domain>` under **Domains**.
+2. Resend issues DNS records — publish all of them with your DNS provider:
+   - **DKIM** — a TXT record (`resend._domainkey.<your-domain>` or similar) that
+     lets Resend sign messages. This is the single biggest deliverability lever.
+   - **Custom Return-Path (bounce) domain** — an MX and a TXT record on a
+     subdomain such as `send.<your-domain>`. This aligns SPF against your domain.
+3. **SPF** is satisfied via the Return-Path records above — you do **not** need
+   to edit any root-domain SPF record *unless you already send mail from
+   `<your-domain>` through another provider*, in which case merge Resend's
+   `include:` into your existing single `v=spf1 …` record (one SPF record only).
+4. Wait for Resend to show the domain as **Verified** before sending.
+
+## 2. Sending identity
+
+- Verify the **root domain** so the From address is `something@<your-domain>`.
+- Send from a **monitored** address (e.g. `hello@<your-domain>`), not `noreply@`.
+  A monitored mailbox that receives replies earns engagement reputation; a
+  `noreply@` address quietly accrues a penalty. If From must stay unmonitored,
+  set `REPLY_TO_EMAIL` to a monitored address instead (the app adds it as
+  `Reply-To` on the user-facing emails).
+- Keep the From domain **aligned with `APP_URL`**. Magic-link URLs point at
+  `APP_URL`; when the link domain matches the From domain, DMARC aligns and
+  recipients see a consistent identity. Misalignment looks like phishing.
+- **Subdomain isolation** (e.g. sending from `mail.<your-domain>`) is a valid
+  later option to protect the root domain's reputation, but it is not required
+  to start. Begin on the root domain; split out a subdomain only if you add
+  higher-volume or riskier streams later.
+
+## 3. DMARC progression
+
+Publish a DMARC policy at `_dmarc.<your-domain>` (TXT) and tighten it in stages:
+
+1. Start in monitor mode:
+   ```
+   v=DMARC1; p=none; rua=mailto:dmarc@<your-domain>; fo=1
+   ```
+2. Monitor the aggregate (`rua`) reports for **2–4 weeks**. Confirm all
+   legitimate mail passes SPF and/or DKIM with alignment.
+3. Move to `p=quarantine` (spam-folder failures). Monitor again.
+4. Move to `p=reject` (drop failures outright) once you are confident no
+   legitimate mail fails.
+
+Never jump straight to `p=reject` — you will silently drop real mail during any
+misconfiguration.
+
+## 4. Verification checklist
+
+- **Gmail "Show original"** — send a magic link to a Gmail account, open the
+  message, ⋮ → *Show original*. SPF, DKIM, and DMARC must all read **PASS**.
+- **[mail-tester.com](https://www.mail-tester.com)** — send to the address it
+  gives you; aim for **10/10**. It flags missing records, blocklists, and
+  content issues.
+- **[Google Postmaster Tools](https://postmaster.google.com)** — add and verify
+  `<your-domain>` to watch domain reputation and spam rate over time.
+
+## 5. Non-goals
+
+Deliberately **not** implemented, and why:
+
+- **List-Unsubscribe / RFC 8058** — a bulk/marketing requirement. It is
+  semantically wrong on transactional auth mail (you can't "unsubscribe" from
+  your own login code).
+- **BIMI** — logo-in-inbox; requires a VMC certificate and enforced DMARC for
+  marginal benefit on transactional mail.
+- **MTA-STS** — inbound transport security; irrelevant to an outbound-only
+  transactional sender.
+- **Open/click tracking** — keep Resend's open and click tracking **OFF**.
+  Click tracking rewrites links through a shared tracking domain, which hurts
+  deliverability and makes magic-link URLs look untrustworthy.

--- a/src/server/services/email-providers/console.ts
+++ b/src/server/services/email-providers/console.ts
@@ -8,6 +8,18 @@ export class ConsoleLogProvider implements EmailProvider {
       "================================",
       `To: ${message.to.name ? `${message.to.name} <${message.to.email}>` : message.to.email}`,
       `From: ${message.from.name ? `${message.from.name} <${message.from.email}>` : message.from.email}`,
+      ...(message.replyTo
+        ? [
+            `Reply-To: ${message.replyTo.name ? `${message.replyTo.name} <${message.replyTo.email}>` : message.replyTo.email}`,
+          ]
+        : []),
+      ...(message.headers
+        ? [
+            `Headers: ${Object.entries(message.headers)
+              .map(([k, v]) => `${k}: ${v}`)
+              .join(", ")}`,
+          ]
+        : []),
       `Subject: ${message.subject}`,
       "",
       "HTML Content:",

--- a/src/server/services/email-providers/resend.ts
+++ b/src/server/services/email-providers/resend.ts
@@ -1,6 +1,23 @@
 // Requires: bun add resend
 import { Resend } from "resend";
-import type { EmailMessage, EmailProvider } from "../email";
+import type { EmailAddress, EmailMessage, EmailProvider } from "../email";
+
+/**
+ * Render an address as an RFC 5322 header value. Display names containing
+ * specials (comma, quote, angle brackets, etc.) must be quoted or the From
+ * header is malformed — e.g. a FROM_NAME of `Acme, Inc.` splits into two
+ * addresses without this.
+ */
+const formatAddress = (addr: EmailAddress): string => {
+  if (!addr.name) {
+    return addr.email;
+  }
+  const needsQuoting = /[(),.:;<>@[\]"]/.test(addr.name);
+  const name = needsQuoting
+    ? `"${addr.name.replace(/([\\"])/g, "\\$1")}"`
+    : addr.name;
+  return `${name} <${addr.email}>`;
+};
 
 export class ResendProvider implements EmailProvider {
   private client: Resend;
@@ -14,15 +31,13 @@ export class ResendProvider implements EmailProvider {
 
   async send(message: EmailMessage): Promise<void> {
     const response = await this.client.emails.send({
-      from: message.from.name
-        ? `${message.from.name} <${message.from.email}>`
-        : message.from.email,
-      to: message.to.name
-        ? `${message.to.name} <${message.to.email}>`
-        : message.to.email,
+      from: formatAddress(message.from),
+      to: formatAddress(message.to),
       subject: message.subject,
       html: message.html,
       text: message.text,
+      ...(message.replyTo ? { replyTo: formatAddress(message.replyTo) } : {}),
+      ...(message.headers ? { headers: message.headers } : {}),
     });
 
     if (response.error) {

--- a/src/server/services/email.test.ts
+++ b/src/server/services/email.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   type EmailMessage,
   type EmailProvider,
@@ -93,6 +93,65 @@ describe("Email Service", () => {
       const message = mockProvider.sentMessages[0];
       expect(message.to.email).toBe("noname@example.com");
       expect(message.to.name).toBeUndefined();
+    });
+
+    test("adds a unique X-Entity-Ref-ID header to each magic link email", async () => {
+      await emailService.sendMagicLink({
+        to: { email: "user@example.com" },
+        magicLinkUrl: "https://example.com/magic?token=a",
+        expiryMinutes: 15,
+      });
+      await emailService.sendMagicLink({
+        to: { email: "user@example.com" },
+        magicLinkUrl: "https://example.com/magic?token=b",
+        expiryMinutes: 15,
+      });
+
+      const refs = mockProvider.sentMessages.map(
+        (m) => m.headers?.["X-Entity-Ref-ID"],
+      );
+      expect(refs.every((r) => typeof r === "string" && r.length > 0)).toBe(
+        true,
+      );
+      expect(new Set(refs).size).toBe(2);
+    });
+
+    test("omits Reply-To when REPLY_TO_EMAIL is unset", async () => {
+      const original = process.env.REPLY_TO_EMAIL;
+      delete process.env.REPLY_TO_EMAIL;
+
+      await emailService.sendMagicLink({
+        to: { email: "user@example.com" },
+        magicLinkUrl: "https://example.com/magic",
+        expiryMinutes: 15,
+      });
+
+      expect(mockProvider.sentMessages[0].replyTo).toBeUndefined();
+
+      if (original !== undefined) {
+        process.env.REPLY_TO_EMAIL = original;
+      }
+    });
+
+    test("sets Reply-To when REPLY_TO_EMAIL is set", async () => {
+      const original = process.env.REPLY_TO_EMAIL;
+      process.env.REPLY_TO_EMAIL = "support@yourdomain.com";
+
+      await emailService.sendMagicLink({
+        to: { email: "user@example.com" },
+        magicLinkUrl: "https://example.com/magic",
+        expiryMinutes: 15,
+      });
+
+      expect(mockProvider.sentMessages[0].replyTo?.email).toBe(
+        "support@yourdomain.com",
+      );
+
+      if (original === undefined) {
+        delete process.env.REPLY_TO_EMAIL;
+      } else {
+        process.env.REPLY_TO_EMAIL = original;
+      }
     });
 
     test("uses environment variables for from address when available", async () => {
@@ -236,5 +295,97 @@ describe("ConsoleLogProvider", () => {
     expect(output).toContain("Test Subject");
     expect(output).toContain("<p>Test HTML</p>");
     expect(output).toContain("Test text");
+  });
+
+  test("logs Reply-To and Headers when present", async () => {
+    const { ConsoleLogProvider } = await import("./email-providers/console");
+    const provider = new ConsoleLogProvider();
+
+    const originalLog = console.log;
+    const logCalls: string[] = [];
+    console.log = (message: string) => {
+      logCalls.push(message);
+    };
+
+    const message: EmailMessage = {
+      to: { email: "test@example.com" },
+      from: { email: "from@example.com" },
+      replyTo: { email: "support@yourdomain.com" },
+      headers: { "X-Entity-Ref-ID": "abc-123" },
+      subject: "Test Subject",
+      html: "<p>Test HTML</p>",
+    };
+
+    await provider.send(message);
+
+    console.log = originalLog;
+
+    const output = logCalls[0];
+    expect(output).toContain("Reply-To: support@yourdomain.com");
+    expect(output).toContain("Headers: X-Entity-Ref-ID: abc-123");
+  });
+});
+
+describe("ResendProvider", () => {
+  type SentPayload = {
+    from: string;
+    to: string;
+    replyTo?: string;
+    headers?: Record<string, string>;
+  };
+
+  const loadProvider = async (
+    capture: (payload: SentPayload) => void,
+  ): Promise<typeof import("./email-providers/resend").ResendProvider> => {
+    mock.module("resend", () => ({
+      Resend: class {
+        emails = {
+          send: async (payload: SentPayload) => {
+            capture(payload);
+            return { data: { id: "test" }, error: null };
+          },
+        };
+      },
+    }));
+    const mod = await import("./email-providers/resend");
+    return mod.ResendProvider;
+  };
+
+  test("forwards replyTo and headers to the Resend client", async () => {
+    let sent: SentPayload | undefined;
+    const ResendProvider = await loadProvider((p) => {
+      sent = p;
+    });
+    const provider = new ResendProvider("re_test_key");
+
+    await provider.send({
+      to: { email: "user@example.com" },
+      from: { email: "hello@billet.example", name: "Billet" },
+      replyTo: { email: "support@billet.example" },
+      headers: { "X-Entity-Ref-ID": "ref-1" },
+      subject: "Hello",
+      html: "<p>Hi</p>",
+    });
+
+    expect(sent?.replyTo).toBe("support@billet.example");
+    expect(sent?.headers).toEqual({ "X-Entity-Ref-ID": "ref-1" });
+    expect(sent?.from).toBe("Billet <hello@billet.example>");
+  });
+
+  test("RFC 5322-quotes a From display name containing a comma", async () => {
+    let sent: SentPayload | undefined;
+    const ResendProvider = await loadProvider((p) => {
+      sent = p;
+    });
+    const provider = new ResendProvider("re_test_key");
+
+    await provider.send({
+      to: { email: "user@example.com" },
+      from: { email: "hello@billet.example", name: "Billet, Inc." },
+      subject: "Hello",
+      html: "<p>Hi</p>",
+    });
+
+    expect(sent?.from).toBe('"Billet, Inc." <hello@billet.example>');
   });
 });

--- a/src/server/services/email.ts
+++ b/src/server/services/email.ts
@@ -6,9 +6,11 @@ export interface EmailAddress {
 export interface EmailMessage {
   to: EmailAddress;
   from: EmailAddress;
+  replyTo?: EmailAddress;
   subject: string;
   html: string;
   text?: string;
+  headers?: Record<string, string>;
 }
 
 export interface EmailProvider {
@@ -27,6 +29,7 @@ export class EmailService {
   async sendMagicLink(data: MagicLinkEmailData): Promise<void> {
     const fromEmail = process.env.FROM_EMAIL as string;
     const fromName = process.env.FROM_NAME as string;
+    const replyTo = process.env.REPLY_TO_EMAIL;
 
     const message: EmailMessage = {
       to: data.to,
@@ -34,6 +37,10 @@ export class EmailService {
         email: fromEmail,
         name: fromName,
       },
+      ...(replyTo ? { replyTo: { email: replyTo } } : {}),
+      // Unique per send so Gmail doesn't collapse consecutive magic links into
+      // one thread — the recipient always sees the newest link.
+      headers: { "X-Entity-Ref-ID": crypto.randomUUID() },
       subject: "Your magic link to sign in",
       html: this.renderMagicLinkTemplate(data),
       text: this.renderMagicLinkText(data),

--- a/src/server/utils/env.ts
+++ b/src/server/utils/env.ts
@@ -33,5 +33,20 @@ export function validateEnv(): void {
     process.exit(1);
   }
 
+  if (
+    process.env.EMAIL_PROVIDER === "resend" &&
+    (process.env.FROM_EMAIL as string).endsWith("@example.com")
+  ) {
+    log.error(
+      "env",
+      "FROM_EMAIL is still the @example.com placeholder — Resend will reject it or it will land in spam",
+    );
+    log.error(
+      "env",
+      "Set FROM_EMAIL to an address on a Resend-verified domain (see runbooks/EMAIL.md)",
+    );
+    process.exit(1);
+  }
+
   log.info("env", "Environment variables validated");
 }


### PR DESCRIPTION
Ports the framework-level email-deliverability hardening from stratum-thermal PR #26 into the Billet stack. Fixes the core `ResendProvider` bug where `replyTo` and custom `headers` were silently dropped, and RFC 5322-quotes display names so a `FROM_NAME` containing a comma no longer produces a malformed `From` header. Magic-link emails now carry a unique `X-Entity-Ref-ID` (stops Gmail thread-collapsing) plus an optional `Reply-To` from `REPLY_TO_EMAIL`, and startup fails fast when `EMAIL_PROVIDER=resend` while `FROM_EMAIL` is still the `@example.com` placeholder. Adds a domain-agnostic `runbooks/EMAIL.md` documenting SPF/DKIM/DMARC setup (linked from the README and `.env.example`). Full test suite (256) and `bun run check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)