### PR TITLE
Add first-class SEO defaults (sitemap, robots, structured data, indexing policy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 docs
 .claude
 .worktrees
+.gstack

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ A `railway.json` is included with build and start commands pre-configured. Deplo
 
 > **Email deliverability:** When sending real mail via Resend, follow [runbooks/EMAIL.md](runbooks/EMAIL.md) to set up SPF, DKIM, and DMARC — without it, magic links land in spam.
 
+> **SEO:** Before your first deploy, set `SITE_URL` (and the `Sitemap:` line in `public/robots.txt`) to your production domain — see [runbooks/SEO.md](runbooks/SEO.md) for the canonical-URL config, sitemap, indexing policy, and verification steps.
+
 ### Database
 
 Billet uses PostgreSQL through Bun's built-in `Bun.SQL` — no ORM, no driver dependency. Migrations run automatically on server startup — pending migrations are applied before the server accepts requests. If a migration fails, the server won't start (fail-safe).

--- a/START_PROMPT.md
+++ b/START_PROMPT.md
@@ -53,6 +53,9 @@ Replace **Billet** with the chosen project name across the codebase. This is a c
 | `src/server/templates/forms.tsx` | Page title |
 | `src/server/templates/projects.tsx` | Page title |
 | `src/server/components/layouts.tsx` | Logo text in `<span>Billet</span>` |
+| `src/server/services/seo.ts` | `SITE_NAME` and `SITE_DESCRIPTION` → project name and description |
+
+> **Note:** `src/server/services/seo.ts` also defines `SITE_URL` (currently `https://billet.alexprice.dev`), the canonical origin used for `<link rel="canonical">`, Open Graph tags, the XML sitemap, and JSON-LD across every page. `public/robots.txt` has a matching hardcoded `Sitemap:` URL. Point both at your own production domain before deploying — see [runbooks/SEO.md](runbooks/SEO.md) §1.
 
 ## 3. Remove original repo references
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Disallow: /admin
+Disallow: /api/
+Disallow: /auth/
+
+Sitemap: https://billet.alexprice.dev/sitemap.xml

--- a/runbooks/SEO.md
+++ b/runbooks/SEO.md
@@ -1,0 +1,145 @@
+# SEO Runbook
+
+Billet ships first-class SEO defaults: server-rendered metadata, a canonical
+URL on every page, `robots.txt`, an XML sitemap, site-level JSON-LD, an explicit
+indexing policy per page, and trailing-slash canonicalisation. This runbook
+covers the one required config step, how to extend each piece as you add pages,
+and how to verify it in production.
+
+Everything here is server-side — crawlers and AI agents get the full picture in
+the initial HTML response, no client JS required.
+
+## 1. Set the canonical site URL (required)
+
+All absolute URLs — canonicals, Open Graph tags, the sitemap, and JSON-LD — are
+built from a single constant. Set it to your production origin **before you
+deploy**, or search engines will index and link the placeholder domain.
+
+- Edit `SITE_URL` in [`src/server/services/seo.ts`](../src/server/services/seo.ts).
+- Use the scheme + host with **no trailing slash**: `https://example.com`.
+- Keep it aligned with `APP_URL` (the env var magic-link emails use). A mismatch
+  between the link domain and the canonical domain looks like cloaking to Google.
+
+`SITE_NAME` and `SITE_DESCRIPTION` live in the same file and feed the JSON-LD and
+the default `<meta name="description">`. Update them to match your product.
+
+## 2. Per-page metadata
+
+Every page renders through `Layout` (or `BaseLayout` for chrome-less pages) in
+[`src/server/components/layouts.tsx`](../src/server/components/layouts.tsx). Each
+page passes its own metadata as props:
+
+| Prop | What it controls | Notes |
+|---|---|---|
+| `title` | `<title>` + `og:title` + `twitter:title` | Unique per page; keep under ~60 chars |
+| `description` | `<meta name="description">` + OG/Twitter | Unique per page; ~150 chars. Falls back to `SITE_DESCRIPTION` |
+| `canonicalPath` | `<link rel="canonical">` + `og:url` | Path only (e.g. `/stack`); resolved against `SITE_URL` |
+| `noindex` | `<meta name="robots" content="noindex, nofollow">` | See §4 |
+
+Rule: **every page sets `title`, `description`, and `canonicalPath`.** The shared
+`HeadMeta` component keeps `Layout` and `BaseLayout` from drifting, so you only
+set these once per page.
+
+## 3. Adding a new public page to the sitemap
+
+The sitemap is generated, not hand-maintained. To include a new indexable page:
+
+1. Add its canonical path to `SITEMAP_PATHS` in
+   [`src/server/services/seo.ts`](../src/server/services/seo.ts).
+2. That's it — `/sitemap.xml` (served by
+   [`controllers/app/sitemap.ts`](../src/server/controllers/app/sitemap.ts))
+   rebuilds from that list on every request.
+
+Only list **canonical, indexable, public** URLs. Do **not** add `noindex` pages
+(`/admin`, `/login`), API endpoints, auth callbacks, or paginated/filtered
+variants. A sitemap that lists non-indexable URLs is a quality signal against you.
+
+## 4. Marking a page `noindex`
+
+Private, thin, staging, or duplicate pages must carry an explicit `noindex`. Pass
+the `noindex` prop:
+
+```tsx
+<Layout title="Admin" canonicalPath="/admin" noindex name="admin" ...>
+```
+
+Currently applied to `/admin` (private) and `/login` (thin/private). When
+`noindex` is set, the page also **omits the site JSON-LD** — you don't want
+structured data on pages you're telling crawlers to ignore.
+
+Also add the path to `Disallow:` in [`public/robots.txt`](../public/robots.txt)
+if you want to save crawl budget — but note `Disallow` only blocks crawling, it
+does **not** guarantee de-indexing. `noindex` is what removes a page from the
+index; a page must be crawlable for the `noindex` to be seen. Don't `Disallow` a
+path you also `noindex` unless it's already de-indexed.
+
+## 5. robots.txt
+
+[`public/robots.txt`](../public/robots.txt) is a static file served from the
+public dir. It:
+
+- allows all user-agents by default,
+- disallows `/admin`, `/api/`, and `/auth/`,
+- points crawlers at the sitemap.
+
+The `Sitemap:` line must be an **absolute URL** — update it to your production
+domain to match `SITE_URL` (this file is static, so it isn't templated).
+
+## 6. Structured data (JSON-LD)
+
+Site-level `WebSite` + `Organization` JSON-LD is injected into every indexable
+page's `<head>` by `siteStructuredData()` in
+[`src/server/services/seo.ts`](../src/server/services/seo.ts).
+
+To add **page-specific** structured data (e.g. `Article`, `Product`,
+`BreadcrumbList`, `FAQPage`), build the object in the page's controller/template
+and render it as its own `<script type="application/ld+json">`. Keep it a
+`JSON.stringify` of a plain object — never interpolate unescaped user input into
+a JSON-LD block. Validate with the Rich Results Test (§8).
+
+## 7. URLs, redirects, and headings
+
+- **Canonicalisation** — `src/server/main.ts` issues a `308` redirect from any
+  trailing-slash path to its slash-free form (e.g. `/stack/` → `/stack`),
+  preserving the query string. One URL per page, no duplicate crawling.
+- **URL structure** — keep new routes lowercase, hyphenated, descriptive, and
+  shallow. Treat URLs as a stable public API; avoid renaming a live URL, and
+  `301`/`308` it to the new location if you must.
+- **Headings** — every page has exactly one `<h1>` and never skips levels
+  (`h1` → `h2` → `h3`). Headings are for outline, not visual sizing — style with
+  CSS instead of reaching for a bigger tag.
+
+## 8. Verification checklist
+
+After deploying (replace the host with your production domain):
+
+- **Sitemap** — `curl -sI https://example.com/sitemap.xml` returns `200` with
+  `Content-Type: application/xml`; the body lists only canonical public URLs.
+- **robots** — `curl -s https://example.com/robots.txt` shows the disallow rules
+  and the absolute `Sitemap:` line.
+- **Redirect** — `curl -sI https://example.com/stack/` returns `308` with a
+  `Location` of the slash-free path.
+- **Indexing policy** — view-source on a public page shows no `noindex`; on
+  `/admin` and `/login` it shows `<meta name="robots" content="noindex, nofollow">`.
+- **Structured data** — run a public URL through the
+  [Rich Results Test](https://search.google.com/test/rich-results); the
+  `WebSite`/`Organization` graph parses with no errors.
+- **Search Console** — add and verify the property at
+  [Google Search Console](https://search.google.com/search-console), submit
+  `sitemap.xml`, and watch Coverage for `noindex`/soft-404/crawl errors.
+
+## 9. Non-goals
+
+Deliberately **not** implemented, and why:
+
+- **Sitemap index files** — only needed above 50,000 URLs or to split by content
+  type. Add one (a sitemap of sitemaps) if the site ever grows that large.
+- **Image / video sitemap extensions** — useful when media is loaded dynamically
+  or hosted on a CDN crawlers can't reach. Not needed for the current static
+  assets in `public/`.
+- **Breadcrumbs (`BreadcrumbList`)** — the site is flat (one level deep), so
+  there's no hierarchy trail to mark up. Add breadcrumbs + JSON-LD if you
+  introduce nested sections.
+- **IndexNow** — an optional ping protocol for Bing/Yandex/Naver/Seznam (Google
+  does not participate). Worth adding if those engines matter and content changes
+  frequently; skipped for a low-churn marketing site.

--- a/src/client/pages/home.css
+++ b/src/client/pages/home.css
@@ -55,6 +55,54 @@
     }
   }
 
+  .hero-announce {
+    display: flex;
+    width: fit-content;
+    max-width: 100%;
+    align-items: center;
+    gap: 8px;
+    margin: 0 auto 1.75rem;
+    padding: 7px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(245, 158, 11, 0.45);
+    background: rgba(245, 158, 11, 0.06);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    line-height: 1;
+    color: var(--color-text);
+    text-decoration: none;
+    transition: all 150ms ease;
+
+    &:hover {
+      border-color: rgba(245, 158, 11, 0.65);
+      background: rgba(245, 158, 11, 0.1);
+      transform: translateY(-1px);
+    }
+  }
+
+  .hero-announce-icon {
+    flex-shrink: 0;
+    color: #f59e0b;
+    filter: drop-shadow(0 0 6px rgba(245, 158, 11, 0.5));
+  }
+
+  .hero-announce-text {
+    background: linear-gradient(90deg, #fbbf24, var(--color-text));
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    font-weight: 600;
+  }
+
+  .hero-announce-arrow {
+    color: #f59e0b;
+    transition: transform 150ms ease;
+  }
+
+  .hero-announce:hover .hero-announce-arrow {
+    transform: translateX(3px);
+  }
+
   .hero-tag {
     display: inline-block;
     font-size: 0.75rem;

--- a/src/server/components/layouts.tsx
+++ b/src/server/components/layouts.tsx
@@ -1,13 +1,14 @@
 import type React from "react";
 
 import { getAssetUrl } from "../services/assets";
+import {
+  SITE_DESCRIPTION,
+  SITE_URL,
+  siteStructuredData,
+} from "../services/seo";
 import type { User } from "../services/users";
 import { Logo } from "./logo";
 import { Nav } from "./nav";
-
-const SITE_URL = "https://billet.alexprice.dev";
-const SITE_DESCRIPTION =
-  "Full-stack TypeScript starter — designed to be built on by AI coding agents";
 
 // The site is dark-only (see `colorScheme: "dark"` on <html>), so theme-color
 // matches --color-bg from style.css rather than shipping light/dark variants.
@@ -20,11 +21,17 @@ interface HeadMetaProps {
   title: string;
   description: string;
   canonicalPath?: string;
+  noindex?: boolean;
 }
 
 // Shared <head> essentials for both Layout and BaseLayout, so the two can't
 // drift out of sync (e.g. one missing the description or canonical tag).
-function HeadMeta({ title, description, canonicalPath }: HeadMetaProps) {
+function HeadMeta({
+  title,
+  description,
+  canonicalPath,
+  noindex,
+}: HeadMetaProps) {
   return (
     <>
       <meta charSet="utf-8" />
@@ -34,6 +41,7 @@ function HeadMeta({ title, description, canonicalPath }: HeadMetaProps) {
       />
       <title>{title}</title>
       <meta name="description" content={description} />
+      {noindex && <meta name="robots" content="noindex, nofollow" />}
       <meta name="color-scheme" content="dark" />
       <meta name="theme-color" content={THEME_COLOR} />
       <link rel="canonical" href={canonicalUrl(canonicalPath)} />
@@ -69,6 +77,7 @@ interface LayoutProps {
   csrfToken?: string;
   description?: string;
   canonicalPath?: string;
+  noindex?: boolean;
 }
 
 export function Layout({
@@ -79,6 +88,7 @@ export function Layout({
   csrfToken,
   description = SITE_DESCRIPTION,
   canonicalPath,
+  noindex,
 }: LayoutProps) {
   return (
     <html lang="en" style={{ colorScheme: "dark" }}>
@@ -87,6 +97,7 @@ export function Layout({
           title={title}
           description={description}
           canonicalPath={canonicalPath}
+          noindex={noindex}
         />
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
@@ -97,6 +108,12 @@ export function Layout({
         <meta name="twitter:title" content={title} />
         <meta name="twitter:description" content={description} />
         <meta name="twitter:image" content={`${SITE_URL}/og-image.png`} />
+        {!noindex && (
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: siteStructuredData() }}
+          />
+        )}
         <script
           type="importmap"
           dangerouslySetInnerHTML={{
@@ -143,6 +160,7 @@ interface BaseLayoutProps {
   children: React.ReactNode;
   description?: string;
   canonicalPath?: string;
+  noindex?: boolean;
 }
 
 export function BaseLayout({
@@ -150,6 +168,7 @@ export function BaseLayout({
   children,
   description = SITE_DESCRIPTION,
   canonicalPath,
+  noindex,
 }: BaseLayoutProps) {
   return (
     <html lang="en" style={{ colorScheme: "dark" }}>
@@ -158,6 +177,7 @@ export function BaseLayout({
           title={title}
           description={description}
           canonicalPath={canonicalPath}
+          noindex={noindex}
         />
       </head>
       <body>{children}</body>

--- a/src/server/controllers/app/index.ts
+++ b/src/server/controllers/app/index.ts
@@ -1,4 +1,5 @@
 export { forms } from "./forms";
 export { home } from "./home";
 export { projects } from "./projects";
+export { sitemap } from "./sitemap";
 export { stack } from "./stack";

--- a/src/server/controllers/app/sitemap.test.ts
+++ b/src/server/controllers/app/sitemap.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { SITE_URL, SITEMAP_PATHS } from "../../services/seo";
+import { sitemap } from "./sitemap";
+
+describe("Sitemap Controller", () => {
+  test("serves valid XML with the correct content type", async () => {
+    const response = sitemap.index();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/xml; charset=utf-8",
+    );
+    expect(body).toStartWith('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(body).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+  });
+
+  test("lists every public path as an absolute URL under SITE_URL", async () => {
+    const body = await sitemap.index().text();
+
+    for (const path of SITEMAP_PATHS) {
+      const loc = new URL(path, SITE_URL).href;
+      expect(body).toContain(`<loc>${loc}</loc>`);
+    }
+  });
+
+  test("omits private and non-indexable routes", async () => {
+    const body = await sitemap.index().text();
+
+    expect(body).not.toContain("/admin");
+    expect(body).not.toContain("/login");
+    expect(body).not.toContain("/api/");
+  });
+});

--- a/src/server/controllers/app/sitemap.ts
+++ b/src/server/controllers/app/sitemap.ts
@@ -1,0 +1,12 @@
+import { buildSitemapXml } from "../../services/seo";
+
+export const sitemap = {
+  index(): Response {
+    return new Response(buildSitemapXml(), {
+      headers: {
+        "Content-Type": "application/xml; charset=utf-8",
+        "Cache-Control": "public, max-age=3600",
+      },
+    });
+  },
+};

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -23,6 +23,17 @@ const server = Bun.serve({
   async fetch(req) {
     const url = new URL(req.url);
 
+    // Canonicalise trailing slashes: every path has exactly one URL. Requests
+    // for "/stack/" 308-redirect to "/stack" (preserving the query string) so
+    // crawlers never index duplicate slashed/unslashed variants.
+    if (url.pathname !== "/" && url.pathname.endsWith("/")) {
+      const canonical = url.pathname.replace(/\/+$/, "");
+      return new Response(null, {
+        status: 308,
+        headers: { Location: canonical + url.search },
+      });
+    }
+
     // Lightweight liveness check for the platform healthcheck. Intentionally
     // does not touch the DB — a transient DB blip should not cause the host to
     // cycle the instance.

--- a/src/server/routes/app.tsx
+++ b/src/server/routes/app.tsx
@@ -1,9 +1,10 @@
-import { forms, home, projects, stack } from "../controllers/app";
+import { forms, home, projects, sitemap, stack } from "../controllers/app";
 import { callback, login, logout } from "../controllers/auth";
 import { createRouteHandler } from "../utils/route-handler";
 
 export const appRoutes = {
   "/": home.index,
+  "/sitemap.xml": sitemap.index,
   "/stack": stack.index,
   "/forms": createRouteHandler({
     GET: forms.index,

--- a/src/server/services/seo.ts
+++ b/src/server/services/seo.ts
@@ -1,0 +1,51 @@
+// Single source of truth for the site's public identity and SEO artefacts
+// (sitemap, structured data). Templates and controllers import from here so the
+// canonical host, name, and description can't drift across the codebase.
+
+export const SITE_URL = "https://billet.alexprice.dev";
+export const SITE_NAME = "Billet";
+export const SITE_DESCRIPTION =
+  "Full-stack TypeScript starter — designed to be built on by AI coding agents";
+
+// Public, indexable routes included in the sitemap. Private or noindex routes
+// (/login, /admin), API endpoints, and auth callbacks are intentionally omitted.
+export const SITEMAP_PATHS = ["/", "/stack", "/forms", "/projects"] as const;
+
+const absolute = (path: string): string => new URL(path, SITE_URL).href;
+
+export const buildSitemapXml = (): string => {
+  const urls = SITEMAP_PATHS.map(
+    (path) => `  <url>\n    <loc>${absolute(path)}</loc>\n  </url>`,
+  ).join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+};
+
+// Site-level JSON-LD (WebSite + Organization) injected into every public page's
+// <head>. Gives search engines and AI agents a machine-readable description of
+// the site using the schema.org vocabulary.
+export const siteStructuredData = (): string =>
+  JSON.stringify({
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "@id": `${SITE_URL}/#website`,
+        url: `${SITE_URL}/`,
+        name: SITE_NAME,
+        description: SITE_DESCRIPTION,
+        publisher: { "@id": `${SITE_URL}/#organization` },
+      },
+      {
+        "@type": "Organization",
+        "@id": `${SITE_URL}/#organization`,
+        name: SITE_NAME,
+        url: `${SITE_URL}/`,
+        logo: absolute("/og-image.png"),
+      },
+    ],
+  });

--- a/src/server/templates/admin-dashboard.tsx
+++ b/src/server/templates/admin-dashboard.tsx
@@ -21,6 +21,7 @@ export const AdminDashboard = (props: {
     title="Admin"
     description="Billet admin dashboard — role-protected routes and server-rendered views."
     canonicalPath="/admin"
+    noindex
     name="admin"
     user={props.user}
     csrfToken={props.csrfToken}

--- a/src/server/templates/home.tsx
+++ b/src/server/templates/home.tsx
@@ -19,7 +19,7 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
       <div className="hero-lottie" id="hero-lottie" />
       <a
         className="hero-announce"
-        href="https://github.com/alexpricedev/Billet/commits/main"
+        href="https://github.com/alexpricedev/Billet/pull/31"
       >
         <svg
           className="hero-announce-icon"

--- a/src/server/templates/home.tsx
+++ b/src/server/templates/home.tsx
@@ -17,6 +17,32 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
   >
     <section className="hero">
       <div className="hero-lottie" id="hero-lottie" />
+      <a
+        className="hero-announce"
+        href="https://github.com/alexpricedev/Billet/commits/main"
+      >
+        <svg
+          className="hero-announce-icon"
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4" />
+        </svg>
+        <span className="hero-announce-text">
+          New: first-class SEO defaults
+        </span>
+        <span className="hero-announce-arrow" aria-hidden="true">
+          →
+        </span>
+      </a>
       <p className="hero-tag">Full-stack TypeScript starter</p>
       <h1>
         Designed to be built&nbsp;on

--- a/src/server/templates/login.tsx
+++ b/src/server/templates/login.tsx
@@ -18,6 +18,7 @@ export const Login = ({ state }: LoginProps) => {
       title="Login - Billet"
       description="Log in to Billet with a magic link — no passwords to remember."
       canonicalPath="/login"
+      noindex
     >
       <main className="login-page">
         <div className="login-wrapper">
@@ -28,7 +29,7 @@ export const Login = ({ state }: LoginProps) => {
           </div>
 
           <div className="login-card">
-            <h2 className="login-title">Sign in to your account</h2>
+            <h1 className="login-title">Sign in to your account</h1>
             <p className="login-subtitle">
               We'll send you a magic link to sign in instantly
             </p>


### PR DESCRIPTION
## Overview

Rounds out Billet's **SEO** defaults against [specification.website](https://specification.website), so every project forked from the template ships search- and agent-ready out of the box. All metadata is server-rendered — crawlers and AI agents get the full picture in the initial HTML response.

## What's included

### Discovery
- **`robots.txt`** — allows crawling, keeps `/admin`, `/api/`, and `/auth/` private, and points at the sitemap.
- **`/sitemap.xml`** — generated from a single list of public routes, backed by a new `src/server/services/seo.ts` that centralizes `SITE_URL` / `SITE_NAME` / `SITE_DESCRIPTION`.
- **Structured data** — site-level `WebSite` + `Organization` JSON-LD on every indexable page.

### Indexing control
- **Per-page indexing policy** — a `noindex` prop on `Layout`/`BaseLayout`, applied to private pages like `/admin` and `/login`.
- **Canonical URLs** — trailing-slash `308` redirect (`/stack/` → `/stack`) so each page has exactly one canonical address.
- **Clean heading outlines** — one `<h1>` per page, no skipped levels.

### Polish & docs
- Home hero **announcement pill** (flame icon) linking to this PR.
- **`runbooks/SEO.md`** documenting the setup, plus `START_PROMPT.md` / `README` pointers so forks know to set `SITE_URL` and the `robots.txt` sitemap line for their own domain.

## Verification
- `bun run check` — clean (lint + typecheck, zero warnings)
- `bun run test` — **259 pass, 0 fail** (adds `sitemap.test.ts`, which derives its assertions from `SITE_URL` so forks don't break)
- Live browser checks — sitemap content-type, robots rules, `308` redirect, and per-page `noindex` / JSON-LD all confirmed

## Intentional non-goals
Sitemap-index (only needed above 50k URLs), image/video sitemaps, breadcrumbs (the site is flat), and IndexNow — each documented with its rationale in `runbooks/SEO.md`.