### PR TITLE
Add accessibility baseline (specification.website audit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Run the full suite: `bun run test`
 - **Opt-in interactivity** — sprinkle in any client-side framework per page (ships with a Preact island example loaded via CDN import map)
 - **Page lifecycle system** — `registerPage()` / `PageController` pattern with `init()` and `cleanup()` for per-page JS
 - **Cookie-based flash messages** — HMAC-signed, single-use cookies for post-redirect-get feedback (success banners, validation errors)
+- **Accessibility baseline** — semantic landmarks, labelled form controls, a keyboard focus ring, reduced-motion support, announced flash messages, and captioned data tables out of the box — see [runbooks/ACCESSIBILITY.md](runbooks/ACCESSIBILITY.md)
 - **Asset cache-busting** in production — MD5-hashed filenames with immutable `Cache-Control` headers
 
 ---

--- a/START_PROMPT.md
+++ b/START_PROMPT.md
@@ -76,6 +76,10 @@ The home page (`src/server/templates/home.tsx`) is currently a marketing landing
 
 Replace this with a simple welcome page for their project. Keep it minimal — just a heading with the project name and a short description. They'll build their own home page from here.
 
+> **Note:** The home page currently loads a looping Lottie hero animation (`src/client/pages/home.ts`, gated behind `prefers-reduced-motion`). If your welcome page drops the animation, remove that init logic and the `/cube.json` asset too.
+
+> **Accessibility:** Billet ships a WCAG-aligned baseline (labelled forms, keyboard focus rings, reduced motion, announced flash messages, captioned tables). Once you replace the placeholder theme with your own design language, **colour contrast and forced-colours support become your responsibility** — a framework can't decide your palette. See [runbooks/ACCESSIBILITY.md](runbooks/ACCESSIBILITY.md) for what's handled, what's yours, and how to verify.
+
 ## 5. Delete the stack page
 
 Remove the stack page and all its associated files:

--- a/runbooks/ACCESSIBILITY.md
+++ b/runbooks/ACCESSIBILITY.md
@@ -1,0 +1,122 @@
+# Accessibility Runbook
+
+Billet ships a WCAG-aligned baseline in the framework layer: semantic
+server-rendered HTML, programmatically labelled form controls, a keyboard focus
+ring, reduced-motion support, screen-reader-announced flash messages, and
+captioned data tables. Because everything renders on the server, assistive tech
+gets the full, correct structure in the initial HTML response — no client JS
+required.
+
+This runbook covers what's already handled, what becomes **your**
+responsibility once you build your own design language, the patterns to keep
+following as you add pages, and how to verify it all. It's aligned to the
+[Website Specification — Accessibility](https://specification.website/accessibility)
+checklist (28 items).
+
+## 1. What Billet ships (the baseline)
+
+These are handled in the framework layer and apply to every page automatically:
+
+| Concern | Where | Notes |
+|---|---|---|
+| Document language | `layouts.tsx` | `<html lang="en">` on both layouts |
+| Semantic landmarks | `layouts.tsx` | `<header>` / `<nav>` / `<main>` / `<footer>` |
+| Navigation semantics | `nav.tsx` | `aria-label="Main navigation"` + `aria-current="page"` |
+| Native interactive elements | throughout | Real `<button>` / `<a>` / `<form>` — never `<div onclick>` |
+| Labelled form controls | `form-field.tsx`, templates | Every input has an associated `<label>` (see §3) |
+| Keyboard focus ring | `style.css` | Global `:focus-visible { outline }` — visible, keyboard-only |
+| Reduced motion | `style.css`, `home.ts` | `prefers-reduced-motion` shrinks transitions and stops the hero animation looping |
+| Announced flash messages | `flash.tsx` | `role="alert"` for errors, `role="status"` for success |
+| Data tables | `data-table.tsx`, templates | `<caption>` + `scope="col"` header cells |
+| Accessible authentication | magic-link login | No password puzzle or CAPTCHA; `autocomplete="email"`; paste allowed |
+| Mobile inputs | `style.css` | Inputs are `font-size: 16px` so iOS Safari doesn't zoom on focus |
+| Screen-reader-only text | `.sr-only` utility | `style.css` — visually hidden, still announced |
+
+Icon-only SVGs (e.g. the hero) carry `aria-hidden="true"` and sit next to real
+text, so there are no unnamed links or buttons.
+
+## 2. Your responsibility (the design layer)
+
+Billet ships a placeholder dark theme. The moment you replace it with your own
+design language, these become yours to own — a framework can't decide them for
+you:
+
+- **Colour contrast** — text and meaningful UI must meet WCAG contrast against
+  their background (4.5:1 for body text, 3:1 for large text and UI). Check every
+  colour pair in your palette, not just the defaults. See
+  [contrast](https://specification.website/spec/accessibility/color-contrast/)
+  and the CSS
+  [`contrast-color()`](https://specification.website/spec/accessibility/contrast-color/)
+  function for dynamic backgrounds.
+- **Focus ring visibility** — the global `:focus-visible` outline uses
+  `--color-primary`. If you change the palette, confirm the ring stays clearly
+  visible against every surface it can appear on. Never reintroduce
+  `outline: none` without an equally visible replacement.
+- **Forced colours mode** — Billet is dark-only and does not yet ship a
+  `forced-colors` media block. If your design relies on background colours to
+  convey meaning (e.g. status pills), add
+  [forced-colours](https://specification.website/spec/accessibility/forced-colors/)
+  handling so Windows High Contrast users don't lose it.
+- **Touch targets** — the default buttons clear the 24×24 CSS px WCAG 2.2
+  minimum but not the 44×44 enhanced target. Size your interactive controls
+  accordingly.
+
+## 3. Patterns to follow as you build
+
+Keep the baseline intact by following these when you add pages:
+
+- **Forms** — never rely on a placeholder as a label (it vanishes on input and
+  is invisible to voice control). Wrap fields in `FormField` for a visible
+  label, or add a `.sr-only` `<label htmlFor>` for compact/inline inputs (see
+  the create form in `projects.tsx` and the search island in
+  `project-search.tsx`).
+- **Tables** — use the `DataTable` component, pass a `caption`, and give every
+  header cell `scope="col"` (or `scope="row"`). Pass `captionVisible` if you
+  want the caption shown rather than screen-reader-only.
+- **Dynamic updates** — anything that appears after an action (validation
+  errors, toasts, live results) should be announced. Reuse `Flash`, or render
+  the container with `role="alert"` / `role="status"` / `aria-live`.
+- **Links** — link text must describe its destination on its own. Avoid "click
+  here" / "read more"; screen-reader users navigate by jumping between links.
+- **Images** — every `<img>` needs an `alt` attribute (empty `alt=""` for purely
+  decorative images). Decorative inline SVGs get `aria-hidden="true"`.
+- **Motion** — respect `prefers-reduced-motion`. The global CSS block covers
+  CSS animation/transition; for JS-driven animation (like the Lottie hero),
+  gate autoplay on `matchMedia("(prefers-reduced-motion: reduce)")` as `home.ts`
+  does.
+- **Media** — video you add needs synchronised captions; audio-only content
+  needs a transcript. Auto-captions alone aren't enough.
+- **ARIA** — reach for a native HTML element first. Only add ARIA when nothing
+  native fits ("the first rule of ARIA is don't use ARIA").
+- **Never** add a third-party "accessibility overlay" widget — they don't work,
+  harm screen-reader users, and attract lawsuits.
+
+## 4. Known gaps
+
+Deliberately not shipped in the template — add them if your product needs them:
+
+- **Skip link** — no "skip to main content" link yet. If you grow the header/nav,
+  add one as the first focusable element in `<body>` targeting `#main-content`
+  (add the `id` to `<main>`). See
+  [skip links](https://specification.website/spec/accessibility/skip-links/).
+- **Forced colours mode** — see §2.
+- **Captions / transcripts** — no media ships in the template; add these
+  alongside any audio or video you introduce.
+
+## 5. How to verify
+
+Before you ship a new page or a redesign:
+
+1. **Keyboard only** — unplug the mouse. Tab through the page: every control
+   must be reachable, in a logical order, with a clearly visible focus ring, and
+   no trap that holds focus.
+2. **Reduce motion** — enable "Reduce motion" in your OS (macOS: System Settings
+   → Accessibility → Display) and reload. Animations should be near-instant and
+   the hero should not loop.
+3. **Screen reader** — run VoiceOver (macOS: ⌘F5) or NVDA over a form: labels
+   should be announced on focus, and a failed submit should announce the error.
+4. **Automated pass** — run [axe DevTools](https://www.deque.com/axe/devtools/)
+   or Lighthouse's Accessibility audit. Treat it as a floor, not a ceiling —
+   automated tools catch roughly a third of issues.
+5. **Contrast** — check your palette's colour pairs with a contrast checker (or
+   the browser DevTools contrast readout) after any theme change.

--- a/src/client/components/project-search.tsx
+++ b/src/client/components/project-search.tsx
@@ -53,7 +53,11 @@ export function ProjectSearch({ projects }: { projects: ProjectItem[] }) {
       <p class="search-count text-tertiary">
         Showing {matchCount} of {projects.length}
       </p>
+      <label htmlFor="project-search-input" class="sr-only">
+        Search projects
+      </label>
       <input
+        id="project-search-input"
         type="text"
         placeholder="Search projects..."
         value={query}

--- a/src/client/pages/home.ts
+++ b/src/client/pages/home.ts
@@ -13,11 +13,16 @@ declare global {
 }
 
 function startAnimation(container: HTMLElement) {
+  // Respect the OS "reduce motion" setting: render a static first frame instead
+  // of an endlessly looping animation for users prone to motion sickness.
+  const reduceMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)",
+  ).matches;
   window.lottie.loadAnimation({
     container,
     renderer: "svg",
-    loop: true,
-    autoplay: true,
+    loop: !reduceMotion,
+    autoplay: !reduceMotion,
     path: "/cube.json",
   });
   container.style.opacity = "0.55";

--- a/src/client/style.css
+++ b/src/client/style.css
@@ -48,6 +48,49 @@ html {
   box-sizing: inherit;
 }
 
+/* Visually hide content while keeping it available to assistive tech. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Keyboard focus ring — high-contrast, only on keyboard/AT focus (not mouse
+   clicks), so removing it from any control requires an explicit override. */
+:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 4px;
+  /* Browsers round the outline to follow border-radius, even on inline links. */
+  border-radius: 4px;
+}
+
+/* Give plain (non-button) inline links horizontal breathing room inside the
+   ring. outline-offset is uniform, so we add inline padding and cancel it with
+   an equal negative margin to avoid shifting surrounding text. */
+a:not([class]):focus-visible {
+  padding-inline: 0.4em;
+  margin-inline: -0.4em;
+}
+
+/* Honour the OS "reduce motion" setting — near-instant animations/transitions
+   for users prone to vestibular distress, migraines, or seizures. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 body {
   font-family: var(--font-main);
   margin: 0;
@@ -158,7 +201,8 @@ select {
   border-radius: var(--radius);
   color: var(--color-text);
   font-family: inherit;
-  font-size: 14px;
+  /* 16px keeps iOS Safari from zooming the viewport on focus. */
+  font-size: 16px;
   padding: 8px 12px;
   transition: border-color 150ms ease;
 
@@ -166,9 +210,8 @@ select {
     color: var(--color-text-quaternary);
   }
 
-  &:focus {
+  &:focus-visible {
     border-color: var(--color-primary);
-    outline: none;
   }
 }
 

--- a/src/server/components/data-table.tsx
+++ b/src/server/components/data-table.tsx
@@ -1,10 +1,25 @@
 interface DataTableProps {
   children: React.ReactNode;
   className?: string;
+  // A caption names the table for screen readers. It's visually hidden by
+  // default (pages usually have a visible heading already); pass
+  // captionVisible to show it.
+  caption?: string;
+  captionVisible?: boolean;
 }
 
-export const DataTable = ({ children, className }: DataTableProps) => (
+export const DataTable = ({
+  children,
+  className,
+  caption,
+  captionVisible,
+}: DataTableProps) => (
   <table className={className ? `data-table ${className}` : "data-table"}>
+    {caption && (
+      <caption className={captionVisible ? undefined : "sr-only"}>
+        {caption}
+      </caption>
+    )}
     {children}
   </table>
 );

--- a/src/server/components/flash.tsx
+++ b/src/server/components/flash.tsx
@@ -4,7 +4,13 @@ interface FlashProps {
 }
 
 export const Flash = ({ type, children }: FlashProps) => (
-  <div className={type === "success" ? "flash-success" : "flash-error"}>
+  // role="alert" (assertive) for errors so screen readers interrupt and announce
+  // them; role="status" (polite) for success so it's announced without cutting
+  // off the user. Both are announced when injected after a post-redirect-get.
+  <div
+    className={type === "success" ? "flash-success" : "flash-error"}
+    role={type === "success" ? "status" : "alert"}
+  >
     {children}
   </div>
 );

--- a/src/server/templates/admin-dashboard.tsx
+++ b/src/server/templates/admin-dashboard.tsx
@@ -33,12 +33,12 @@ export const AdminDashboard = (props: {
       </div>
 
       <div className="admin-table-wrap">
-        <DataTable>
+        <DataTable caption="Users">
           <thead>
             <tr>
-              <th>Email</th>
-              <th>Role</th>
-              <th>Joined</th>
+              <th scope="col">Email</th>
+              <th scope="col">Role</th>
+              <th scope="col">Joined</th>
             </tr>
           </thead>
           <tbody>

--- a/src/server/templates/projects.tsx
+++ b/src/server/templates/projects.tsx
@@ -48,7 +48,11 @@ export const Projects = (props: ProjectsProps): JSX.Element => {
       <section className="card">
         <form method="POST" action="/projects" className="project-form">
           <CsrfField token={props.createCsrfToken} />
+          <label htmlFor="project-title" className="sr-only">
+            Project title
+          </label>
           <input
+            id="project-title"
             type="text"
             name="title"
             placeholder="New project title"
@@ -79,12 +83,16 @@ export const Projects = (props: ProjectsProps): JSX.Element => {
         <p className="text-tertiary">No projects yet.</p>
       ) : (
         <div id="projects-list">
-          <DataTable className="project-list">
+          <DataTable className="project-list" caption="Projects">
             <thead>
               <tr>
-                <th>Title</th>
-                <th>Created by</th>
-                {props.isAuthenticated && <th />}
+                <th scope="col">Title</th>
+                <th scope="col">Created by</th>
+                {props.isAuthenticated && (
+                  <th scope="col">
+                    <span className="sr-only">Actions</span>
+                  </th>
+                )}
               </tr>
             </thead>
             <tbody>
@@ -130,7 +138,7 @@ export const Projects = (props: ProjectsProps): JSX.Element => {
           place.
         </p>
         <div className="card">
-          <DataTable className="endpoint-table">
+          <DataTable className="endpoint-table" caption="API endpoints">
             <tbody>
               <tr>
                 <td>


### PR DESCRIPTION
## Summary

Audits the app against the [specification.website Accessibility checklist](https://specification.website/accessibility) (28 items) and remediates the actionable gaps. Because Billet is a **design-agnostic template**, the colour/contrast items (colour contrast, `contrast-color()`, forced-colours) are deliberately left to the design layer the end user builds — this PR fixes everything the framework layer owns.

Skip link is intentionally deferred.

## What changed

| Item | Change |
|---|---|
| **Focus indicators** | Global high-contrast `:focus-visible` ring (rounded 4px, `outline-offset: 4px`, extra horizontal room on plain inline links); removed the `outline: none` regression on inputs |
| **Reduced motion** | `@media (prefers-reduced-motion: reduce)` safety net; the Lottie hero now gates `autoplay`/`loop` on `matchMedia` |
| **Form labels** | The projects create input and the Preact search island now have real associated labels (placeholder is not a label); added an `.sr-only` utility |
| **Mobile inputs** | Input `font-size` `14px → 16px` so iOS Safari doesn't zoom on focus |
| **Data tables** | `caption` + `scope="col"` on the projects, admin, and endpoints tables (`DataTable` gained a `caption` prop, sr-only by default) |
| **Form errors/status** | `Flash` renders `role="alert"` for errors and `role="status"` for success so assistive tech announces them |

## Docs

- **`runbooks/ACCESSIBILITY.md`** (new) — what's handled, what's the design layer's responsibility, patterns to follow, known gaps, and a verification checklist.
- **README** — "Accessibility baseline" bullet linking the runbook.
- **START_PROMPT.md** — §4 notes the reduced-motion hero logic and that colour contrast/forced-colours become the builder's responsibility once they theme.

## Verification

- `bun run check` (lint + typecheck): clean
- `bun run test`: **259 pass, 0 fail**
- Verified live on `localhost:3000` with the headless browser: label association, `caption` + `scope="col"`, `16px` inputs, the `:focus-visible` ring (`2px solid`, `4px` radius/offset), the reduced-motion rule in the served bundle, and the success/error flash roles.

## Out of scope (design layer)

Colour contrast, `contrast-color()`, and forced-colours mode — documented in the runbook as the builder's responsibility once they replace the placeholder theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)