### PR TITLE
Security hardening + specification.website page refresh + CI docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,5 +20,11 @@ FROM_NAME=Billet
 # Optional — monitored address to receive replies when FROM_EMAIL is unmonitored.
 # REPLY_TO_EMAIL=support@yourdomain.com
 
+# Optional — Contact for /.well-known/security.txt. A bare email is wrapped in
+# mailto:; a mailto:/https:/tel: URI is used as-is. Defaults to a placeholder
+# (security@<your SITE_URL host>). Set a monitored address before launch.
+# See runbooks/SECURITY.md §2.
+# SECURITY_CONTACT=security@yourdomain.com
+
 # Required when EMAIL_PROVIDER=resend
 # RESEND_API_KEY=re_your_key_here

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ A complete magic-link email auth flow: users enter their email, receive a login 
 - **Rate limiting** middleware with configurable sliding-window limits per IP
 - **Session fixation prevention** — sessions are regenerated on login
 - **Environment validation** at startup — the server fails fast with clear error messages if required variables are missing
-- **Response hardening** with security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy)
+- **Response hardening** — security headers on every response (nosniff, frame/clickjacking protection, an enforcing Content Security Policy, Permissions-Policy, HSTS in production), plus `/.well-known/security.txt` and Subresource Integrity on third-party scripts — see [runbooks/SECURITY.md](runbooks/SECURITY.md)
 
 ### Database
 
@@ -266,6 +266,8 @@ A `railway.json` is included with build and start commands pre-configured. Deplo
 > **Email deliverability:** When sending real mail via Resend, follow [runbooks/EMAIL.md](runbooks/EMAIL.md) to set up SPF, DKIM, and DMARC — without it, magic links land in spam.
 
 > **SEO:** Before your first deploy, set `SITE_URL` (and the `Sitemap:` line in `public/robots.txt`) to your production domain — see [runbooks/SEO.md](runbooks/SEO.md) for the canonical-URL config, sitemap, indexing policy, and verification steps.
+
+> **Security:** The HTTP hardening (security headers, CSP, HSTS, SRI) works out of the box, but set `SECURITY_CONTACT` (the `security.txt` reporting address) and add the registrar-level records before launch — see [runbooks/SECURITY.md](runbooks/SECURITY.md) for that plus the TLS, HSTS-preload, CAA, and DNSSEC steps.
 
 ### Database
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Run the full suite: `bun run test`
 - **Biome** linting with zero-warning enforcement (`--max-warnings 0`) — no `any` types, no `console` statements, no unused variables
 - **TypeScript** strict mode with `noUnusedLocals` and `noUnusedParameters`
 - **Husky** pre-commit hooks that run lint and typecheck before every commit
+- **GitHub Actions CI** — lint, build, and the full test suite run on every PR (`.github/workflows/ci.yml`); gate merges behind them with required status checks (see [runbooks/CI.md](runbooks/CI.md))
 - **Structured logging** via `src/server/services/logger.ts` — replaces `console.*` with levelled output (info, warn, error)
 
 ### Frontend
@@ -268,6 +269,8 @@ A `railway.json` is included with build and start commands pre-configured. Deplo
 > **SEO:** Before your first deploy, set `SITE_URL` (and the `Sitemap:` line in `public/robots.txt`) to your production domain — see [runbooks/SEO.md](runbooks/SEO.md) for the canonical-URL config, sitemap, indexing policy, and verification steps.
 
 > **Security:** The HTTP hardening (security headers, CSP, HSTS, SRI) works out of the box, but set `SECURITY_CONTACT` (the `security.txt` reporting address) and add the registrar-level records before launch — see [runbooks/SECURITY.md](runbooks/SECURITY.md) for that plus the TLS, HSTS-preload, CAA, and DNSSEC steps.
+
+> **CI & merge protection:** CI runs on every PR, but check results are advisory until you require them. A fork doesn't inherit branch protection, so nothing stops an auto-merge (GitHub's or Conductor's) from merging a red build — enable required status checks once per repo. See [runbooks/CI.md](runbooks/CI.md).
 
 ### Database
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,3 +94,12 @@ CSRF protection applies to: POST, PUT, PATCH, DELETE
 - **Session Management**: HMAC-protected IDs, secure cookies, 30-day expiration
 - **Input Validation**: Type-safe forms, parameterized queries, XSS prevention
 - **Environment Security**: Crypto pepper, environment isolation, no secret logging
+
+## HTTP Headers, CSP & Transport
+
+The defensive HTTP baseline — security headers on every response, an enforcing
+Content Security Policy, HSTS, `/.well-known/security.txt`, Subresource
+Integrity, and the deploy/DNS steps — lives in
+[`runbooks/SECURITY.md`](runbooks/SECURITY.md). Read it before your first deploy:
+the `security.txt` contact address needs setting, and TLS/HSTS-preload/CAA/DNSSEC
+are host- and registrar-level steps.

--- a/START_PROMPT.md
+++ b/START_PROMPT.md
@@ -80,6 +80,8 @@ Replace this with a simple welcome page for their project. Keep it minimal — j
 
 > **Accessibility:** Billet ships a WCAG-aligned baseline (labelled forms, keyboard focus rings, reduced motion, announced flash messages, captioned tables). Once you replace the placeholder theme with your own design language, **colour contrast and forced-colours support become your responsibility** — a framework can't decide your palette. See [runbooks/ACCESSIBILITY.md](runbooks/ACCESSIBILITY.md) for what's handled, what's yours, and how to verify.
 
+> **Security:** Billet applies security headers, a Content Security Policy, HSTS, Subresource Integrity, and a Clear-Site-Data wipe on logout automatically. Two things need you: set `SECURITY_CONTACT` in your env (the `security.txt` reporting address — it defaults to a placeholder), and if you drop the Lottie hero above, its unpkg script in `src/server/components/layouts.tsx` goes too — one less third-party origin to trust. See [runbooks/SECURITY.md](runbooks/SECURITY.md) for that plus the TLS, HSTS-preload, CAA, and DNSSEC deploy steps.
+
 ## 5. Delete the stack page
 
 Remove the stack page and all its associated files:

--- a/runbooks/CI.md
+++ b/runbooks/CI.md
@@ -1,0 +1,105 @@
+# CI & merge protection Runbook
+
+Billet runs lint, type-check, build, and the full test suite on every pull
+request via GitHub Actions ([`.github/workflows/ci.yml`](../.github/workflows/ci.yml)).
+But **CI results only gate merges if you make the checks _required_** — that's a
+per-repository GitHub setting that a fork or new clone does **not** inherit.
+Until you set it, a PR is mergeable the moment it opens, and any auto-merge
+(GitHub's native one _or_ Conductor's Automerge button) will merge it regardless
+of whether the tests passed.
+
+This runbook covers the pipeline and how to lock merges behind green CI.
+
+## 1. What runs on every PR
+
+Three jobs, chained so a failure short-circuits the rest:
+
+| Check (job name) | Command | Depends on |
+|---|---|---|
+| `Lint & Typecheck` | `bun run check` | — |
+| `Build` | `bun run build` | `Lint & Typecheck` |
+| `Tests` | `bun run test` against a Postgres service | `Build` |
+
+The job **names** above are exactly the check "contexts" GitHub sees — you'll
+reference them by name in §2.
+
+> **Rename the placeholder env.** The `Tests` job in `ci.yml` still ships with
+> template values (`APP_NAME: San Jose`, `POSTGRES_DB` / `DATABASE_URL` pointing
+> at `san-jose-test`). They're internally consistent so tests pass, but rename
+> them to your project for clarity.
+
+## 2. Require the checks before merge
+
+By default GitHub treats check results as **advisory** — informational, not
+blocking. Auto-merge tools (Conductor included) merge by calling GitHub's merge
+API with your credentials, and **GitHub only rejects a merge when the target
+branch has required status checks**. So the fix is server-side and tool-agnostic:
+require the checks on your default branch, and _every_ merge path is gated by
+them.
+
+This also closes a race worth knowing about: because the jobs are chained, when a
+PR first opens only `Lint & Typecheck` exists as a check — `Build` and `Tests`
+haven't registered yet. An auto-merge that acts on "the checks I can see are
+green" could merge after lint and before Tests ever runs. Requiring all three
+names means GitHub holds the merge until each required context reports success.
+
+Apply the rule (the `{owner}`/`{repo}` placeholders resolve from the current
+clone, so this is copy-paste safe in any fork):
+
+```bash
+gh api -X PUT repos/{owner}/{repo}/branches/main/protection --input - <<'JSON'
+{
+  "required_status_checks": { "strict": false, "contexts": ["Lint & Typecheck", "Build", "Tests"] },
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+JSON
+```
+
+- **`enforce_admins: true`** — the required checks apply to _everyone_, including
+  repo admins and the token an auto-merge acts under. This is the part that
+  actually stops a premature merge. Trade-off: you can't hand-override a red
+  build without lifting it first (see §4).
+- **`strict: false`** — merge as soon as checks are green. Set `true` to also
+  require the branch be up to date with `main` first (safer, but forces a
+  rebase/re-run whenever `main` moves).
+- **No required reviews** — this gates on CI only; it doesn't add an approval
+  requirement.
+
+## 3. Verify
+
+A PR whose required checks haven't all passed reports `BLOCKED`:
+
+```bash
+gh pr view <number> --json mergeable,mergeStateStatus
+# mergeStateStatus: "BLOCKED"  → held on required checks (auto-merge can't complete)
+# mergeStateStatus: "CLEAN"    → all required checks green, mergeable
+```
+
+`mergeable: MERGEABLE` only means "no merge conflicts" — it's `mergeStateStatus`
+that reflects the check gate.
+
+## 4. Adjust or remove
+
+```bash
+# Let admins hand-override a red build (turn enforce-admins off):
+gh api -X DELETE repos/{owner}/{repo}/branches/main/protection/enforce_admins
+
+# Re-enable it:
+gh api -X POST repos/{owner}/{repo}/branches/main/protection/enforce_admins
+
+# Remove all protection:
+gh api -X DELETE repos/{owner}/{repo}/branches/main/protection
+```
+
+## 5. Gotchas
+
+- **Branch protection is a GitHub repo setting, not code.** It lives on the
+  remote, not in this repository, so it is not copied when someone forks or
+  re-clones. Each repo that wants gated merges must run §2 once.
+- **Contexts must match job names exactly.** If you rename a job in `ci.yml`
+  (e.g. `Tests` → `Test suite`), update the required `contexts` to match — a
+  required check that never reports keeps every PR blocked forever.
+- **New checks aren't auto-required.** Adding a job to `ci.yml` doesn't make it
+  blocking; add its name to `contexts` if it should gate merges.

--- a/runbooks/SECURITY.md
+++ b/runbooks/SECURITY.md
@@ -1,0 +1,197 @@
+# Security Runbook
+
+Billet ships a defensive HTTP baseline: a single set of security headers on
+**every** response, an enforcing Content Security Policy, HSTS in production,
+a `/.well-known/security.txt`, and Subresource Integrity on its one third-party
+script. Cookies and CSRF are covered separately in the root
+[`SECURITY.md`](../SECURITY.md).
+
+This runbook covers what's applied automatically, the one required config step,
+how to extend each piece, the deploy- and DNS-layer steps a host can't do for
+you, and how to verify it all in production.
+
+Everything except the DNS/transport items is server-side and needs no client JS.
+
+## 1. What's applied automatically
+
+Every response — HTML pages, JSON APIs, static files, redirects, and error
+pages — passes through one checkpoint and leaves with the same security headers.
+The single source of truth is
+[`src/server/utils/security-headers.ts`](../src/server/utils/security-headers.ts),
+wired in [`src/server/main.ts`](../src/server/main.ts) two ways:
+
+- `secureRoutes({...})` wraps every declared route handler.
+- `withSecurityHeaders(await handleFallback(req))` wraps the static/asset/404 path.
+
+`withSecurityHeaders` only fills in headers a response hasn't already set, so a
+route can still override any single header (e.g. a relaxed CSP for one page).
+
+| Header | Value | Notes |
+|---|---|---|
+| `X-Content-Type-Options` | `nosniff` | Stops content-type guessing |
+| `X-Frame-Options` | `DENY` | Legacy clickjacking defence (CSP `frame-ancestors` is the modern one) |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limits URL leakage to other sites |
+| `Cross-Origin-Opener-Policy` | `same-origin` | Isolates our browsing context |
+| `Permissions-Policy` | deny-all baseline, `fullscreen=(self)` | Turns off camera, mic, geolocation, USB, payment, etc. |
+| `Content-Security-Policy` | see §3 | Source allowlist + clickjacking + https upgrade |
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | **Production only** (see §4) |
+
+HSTS is intentionally withheld outside production (`NODE_ENV !== "production"`)
+so local development over plain HTTP doesn't pin `localhost` to HTTPS.
+
+One route sets an extra header of its own: **logout**
+([`controllers/auth/logout.tsx`](../src/server/controllers/auth/logout.tsx))
+sends `Clear-Site-Data: "cookies", "storage"` so the browser wipes cookies and
+client storage on sign-out — defence in depth beyond deleting the session cookie.
+
+## 2. Set the security.txt contact (required before launch)
+
+[RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) `security.txt` tells
+researchers how to report a vulnerability. Billet serves it dynamically at
+`/.well-known/security.txt` from
+[`src/server/services/security-txt.ts`](../src/server/services/security-txt.ts)
+(controller: [`controllers/app/security-txt.ts`](../src/server/controllers/app/security-txt.ts),
+route in [`routes/app.tsx`](../src/server/routes/app.tsx)).
+
+- **`Contact:`** comes from the **`SECURITY_CONTACT`** env var (see
+  [`.env.example`](../.env.example)). A bare email is wrapped in `mailto:`; a
+  fully-qualified `mailto:` / `https:` / `tel:` URI is used as-is:
+
+  ```bash
+  SECURITY_CONTACT=security@yourdomain.com          # → Contact: mailto:security@yourdomain.com
+  SECURITY_CONTACT=https://yourdomain.com/security  # → Contact: https://yourdomain.com/security
+  ```
+
+  With no env set it falls back to `mailto:security@<host-of-SITE_URL>` — a
+  placeholder. Set a **monitored** address before you launch.
+- **`Expires:`** is computed as one year from process start, so it never lapses;
+  it refreshes on every deploy. No action needed.
+- **`Canonical:`** is derived from `SITE_URL` in
+  [`services/seo.ts`](../src/server/services/seo.ts) — the same constant the SEO
+  runbook has you set. If SITE_URL is correct, this is correct.
+
+## 3. Content Security Policy
+
+The policy is enforcing and host-allowlist based. Current directives:
+
+```
+default-src 'self'; base-uri 'none'; object-src 'none'; frame-ancestors 'none';
+img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline';
+script-src 'self' 'unsafe-inline' https://unpkg.com https://esm.sh;
+connect-src 'self'; upgrade-insecure-requests
+```
+
+What it buys today: no other site can frame our pages (`frame-ancestors 'none'`),
+no plugins (`object-src 'none'`), no `<base>` injection (`base-uri 'none'`), any
+stray `http://` subresource is auto-upgraded to HTTPS, and code/styles/images may
+only load from us plus the two named CDNs.
+
+**Adding a new external source.** If you pull a script, style, image, font, or
+API from a new origin, add that origin to the matching directive in
+`security-headers.ts`:
+
+- external `<script src>` → `script-src`
+- external stylesheet or `@font-face` host → `style-src` / `font-src`
+- `<img>` from a CDN → `img-src`
+- `fetch()`/XHR/WebSocket to an API → `connect-src`
+
+Forget one and the browser blocks the resource with a `Refused to load…` console
+error. Test in a real browser after any change (see §6).
+
+**The `'unsafe-inline'` tradeoff.** `script-src` includes `'unsafe-inline'`
+because the page ships an inline import map and inline JSON-LD in
+[`layouts.tsx`](../src/server/components/layouts.tsx). That weakens CSP's XSS
+protection. The hardening path (a follow-up, not done here) is nonce +
+`'strict-dynamic'`: generate a per-request nonce, stamp it on every inline and
+first-party `<script>`, add `'nonce-…' 'strict-dynamic'` to `script-src`, and
+drop `'unsafe-inline'`. The cleanest enabler is self-hosting Preact and lottie so
+there are no CDN scripts and no inline import map to allow.
+
+## 4. Subresource Integrity (third-party scripts)
+
+The homepage loads the lottie animation library from unpkg with a pinned version
+and a cryptographic hash in
+[`layouts.tsx`](../src/server/components/layouts.tsx):
+
+```html
+<script async
+  src="https://unpkg.com/lottie-web@5.13.0/build/player/lottie_light.min.js"
+  integrity="sha384-…" crossorigin="anonymous"></script>
+```
+
+If unpkg ever serves a tampered file, the hash won't match and the browser
+refuses to run it. **SRI requires an exact version** — never point `integrity`
+at a floating range like `@5`.
+
+**Bumping the version.** Recompute the hash for the new file:
+
+```bash
+curl -sL "https://unpkg.com/lottie-web@<NEW>/build/player/lottie_light.min.js" \
+  | openssl dgst -sha384 -binary | openssl base64 -A
+```
+
+Update both the `src` version and the `integrity` value.
+
+**Preact / import map.** Preact is pinned (`@10.28.4`) but loaded via an ES
+module import map, which has no SRI equivalent in current browsers. Pinning the
+exact version is the mitigation. Self-hosting removes the third-party trust
+entirely.
+
+## 5. Deploy & transport layer (host, not code)
+
+- **HTTPS / TLS.** Provided by the platform. Railway terminates TLS and redirects
+  plain HTTP to HTTPS at the edge, so there is no in-app redirect. If you deploy
+  elsewhere, confirm the edge does the HTTP→HTTPS redirect.
+- **HSTS preload.** The header already advertises `preload`. To get baked into
+  browsers, submit the apex domain at [hstspreload.org](https://hstspreload.org)
+  **after** confirming every subdomain is HTTPS-only — preload is hard to undo.
+
+## 6. Verify in production
+
+```bash
+# Headers present on a normal page
+curl -sI https://yourdomain.com/ | grep -iE \
+  'content-security-policy|strict-transport|x-content-type|permissions-policy'
+
+# security.txt serves as text/plain with a real Contact + future Expires
+curl -s https://yourdomain.com/.well-known/security.txt
+```
+
+- **In a browser:** load the site, open the console, confirm no `Refused to
+  load…` / CSP violations and that the hero animation and any islands render.
+- **Scanners:** [securityheaders.com](https://securityheaders.com),
+  [Mozilla Observatory](https://observatory.mozilla.org), and Google's
+  [CSP Evaluator](https://csp-evaluator.withgoogle.com) for policy strength.
+
+Note: Chrome logs harmless `Unrecognized feature` warnings for a few
+`Permissions-Policy` tokens it hasn't implemented (e.g. `battery`, `web-share`).
+They don't affect security; trim those tokens in `security-headers.ts` if you
+want a spotless console.
+
+## 7. DNS layer (registrar, not code)
+
+- **CAA records (recommended).** Restrict which certificate authorities may issue
+  certs for your domain. Confirm your platform's CA first — a wrong CAA blocks
+  renewals. Railway uses Let's Encrypt:
+
+  ```
+  yourdomain.com.  CAA  0 issue "letsencrypt.org"
+  ```
+
+- **DNSSEC (optional).** Enable at your registrar to cryptographically sign DNS
+  records. One-click at most registrars; verify with
+  [dnssec-analyzer.verisignlabs.com](https://dnssec-analyzer.verisignlabs.com).
+
+## 8. Deliberately not implemented (yet)
+
+- **Reporting API (`Reporting-Endpoints` + CSP `report-to`)** — needs a collector
+  endpoint to receive violation reports. Add one to observe CSP breakage in the
+  wild before tightening the policy.
+- **COEP / CORP** — `Cross-Origin-Embedder-Policy` would break the unpkg/esm.sh
+  scripts, and a strict `Cross-Origin-Resource-Policy` would block social scrapers
+  from fetching the OG image. Only `Cross-Origin-Opener-Policy` is set. Revisit
+  COEP if you ever need cross-origin isolation (e.g. `SharedArrayBuffer`).
+- **Trusted Types** (`require-trusted-types-for 'script'`) — pairs naturally with
+  the nonce-based CSP upgrade in §3.
+- **Digest Fields (`Content-Digest`)** — transit-integrity hashes, optional and
+  niche for a site behind HTTPS.

--- a/src/client/pages/home.css
+++ b/src/client/pages/home.css
@@ -345,10 +345,18 @@
   }
 
   /* ── Spec standard ───────────────────────────────────── */
+  /* Bordered amber box echoing the hero announce banner for visual coherence. */
 
   .spec {
-    padding: 4rem 0;
-    border-top: 1px solid var(--color-border);
+    margin: 2rem 0 4rem;
+    padding: 2rem;
+    border: 1px solid rgba(245, 158, 11, 0.45);
+    border-radius: var(--radius);
+    background: rgba(245, 158, 11, 0.06);
+
+    @media (width >= 768px) {
+      padding: 2.5rem;
+    }
 
     h2 {
       margin-bottom: 0.5rem;
@@ -362,9 +370,28 @@
     margin-bottom: 2rem;
 
     a {
-      color: var(--color-primary);
+      color: #fbbf24;
       text-decoration: underline;
     }
+  }
+
+  /* Tint the reused feedback-stack rows into the amber theme. */
+  .spec .feedback-stack {
+    border-color: rgba(245, 158, 11, 0.3);
+    background: rgba(0, 0, 0, 0.15);
+  }
+
+  .spec .stack-row {
+    background: transparent;
+    border-bottom-color: rgba(245, 158, 11, 0.18);
+
+    &:hover {
+      background: rgba(245, 158, 11, 0.08);
+    }
+  }
+
+  .spec .stack-layer {
+    color: #fbbf24;
   }
 
   .spec-note {
@@ -379,7 +406,7 @@
     gap: 6px;
     font-size: 0.875rem;
     font-weight: 500;
-    color: var(--color-primary);
+    color: #f59e0b;
     text-decoration: none;
 
     span {

--- a/src/client/pages/home.css
+++ b/src/client/pages/home.css
@@ -398,8 +398,9 @@
     background: transparent;
     border-bottom-color: rgba(245, 158, 11, 0.18);
 
+    /* Static rows — override the feedback-stack hover, they're not links. */
     &:hover {
-      background: rgba(245, 158, 11, 0.08);
+      background: transparent;
     }
   }
 

--- a/src/client/pages/home.css
+++ b/src/client/pages/home.css
@@ -343,4 +343,55 @@
       grid-template-columns: repeat(3, 1fr);
     }
   }
+
+  /* ── Spec standard ───────────────────────────────────── */
+
+  .spec {
+    padding: 4rem 0;
+    border-top: 1px solid var(--color-border);
+
+    h2 {
+      margin-bottom: 0.5rem;
+    }
+  }
+
+  .spec-lead {
+    max-width: 640px;
+    font-size: 0.9375rem;
+    line-height: 1.75;
+    margin-bottom: 2rem;
+
+    a {
+      color: var(--color-primary);
+      text-decoration: underline;
+    }
+  }
+
+  .spec-note {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+    font-size: 0.8125rem;
+  }
+
+  .spec-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-primary);
+    text-decoration: none;
+
+    span {
+      transition: transform 150ms ease;
+    }
+
+    &:hover {
+      text-decoration: none;
+
+      span {
+        transform: translateX(3px);
+      }
+    }
+  }
 }

--- a/src/client/pages/home.css
+++ b/src/client/pages/home.css
@@ -357,10 +357,23 @@
     @media (width >= 768px) {
       padding: 2.5rem;
     }
+  }
+
+  .spec-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 1rem;
 
     h2 {
-      margin-bottom: 0.5rem;
+      margin-bottom: 0;
     }
+  }
+
+  .spec-icon {
+    flex-shrink: 0;
+    color: #f59e0b;
+    filter: drop-shadow(0 0 6px rgba(245, 158, 11, 0.5));
   }
 
   .spec-lead {

--- a/src/server/components/layouts.tsx
+++ b/src/server/components/layouts.tsx
@@ -147,7 +147,9 @@ export function Layout({
         </footer>
         <script
           async
-          src="https://unpkg.com/lottie-web@5/build/player/lottie_light.min.js"
+          src="https://unpkg.com/lottie-web@5.13.0/build/player/lottie_light.min.js"
+          integrity="sha384-Gr3FGWSrOz4fzm9bvrWwhuQH87JMUCLlOTaHhpddbnlHHWCZPxMeQ3KUPsomzIii"
+          crossOrigin="anonymous"
         />
         <script type="module" src={getAssetUrl("/assets/main.js")} />
       </body>

--- a/src/server/controllers/app/index.ts
+++ b/src/server/controllers/app/index.ts
@@ -1,5 +1,6 @@
 export { forms } from "./forms";
 export { home } from "./home";
 export { projects } from "./projects";
+export { securityTxt } from "./security-txt";
 export { sitemap } from "./sitemap";
 export { stack } from "./stack";

--- a/src/server/controllers/app/security-txt.test.ts
+++ b/src/server/controllers/app/security-txt.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { SITE_URL } from "../../services/seo";
+import { securityTxt } from "./security-txt";
+
+describe("Security.txt Controller", () => {
+  test("serves plain text with the correct content type", async () => {
+    const response = securityTxt.index();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    expect(body).toContain("Contact: mailto:security@");
+  });
+
+  test("includes the RFC 9116 required Expires field as an ISO 8601 timestamp", async () => {
+    const body = await securityTxt.index().text();
+
+    const match = body.match(/^Expires: (.+)$/m);
+    expect(match).not.toBeNull();
+    const expires = new Date(match?.[1] ?? "");
+    expect(expires.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  test("points Canonical at the well-known path under SITE_URL", async () => {
+    const body = await securityTxt.index().text();
+
+    expect(body).toContain(`Canonical: ${SITE_URL}/.well-known/security.txt`);
+  });
+});

--- a/src/server/controllers/app/security-txt.ts
+++ b/src/server/controllers/app/security-txt.ts
@@ -1,0 +1,12 @@
+import { buildSecurityTxt } from "../../services/security-txt";
+
+export const securityTxt = {
+  index(): Response {
+    return new Response(buildSecurityTxt(), {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "public, max-age=86400",
+      },
+    });
+  },
+};

--- a/src/server/controllers/auth/logout.test.ts
+++ b/src/server/controllers/auth/logout.test.ts
@@ -92,6 +92,9 @@ describe("Logout Controller", () => {
 
       expect(response.status).toBe(303);
       expect(response.headers.get("location")).toBe("/login");
+      expect(response.headers.get("clear-site-data")).toBe(
+        '"cookies", "storage"',
+      );
 
       const setCookie = findSetCookie(request, "session_id");
       expect(setCookie).toBeTruthy();

--- a/src/server/controllers/auth/logout.tsx
+++ b/src/server/controllers/auth/logout.tsx
@@ -25,9 +25,15 @@ export const logout = {
 
     clearSessionCookie(req);
 
+    // Clear-Site-Data tells the browser to wipe cookies and client storage for
+    // this origin on sign-out — defence in depth beyond deleting the session
+    // cookie, in case a page cached auth state in localStorage/sessionStorage.
     return new Response("", {
       status: 303,
-      headers: { Location: "/login" },
+      headers: {
+        Location: "/login",
+        "Clear-Site-Data": '"cookies", "storage"',
+      },
     });
   },
 };

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -6,56 +6,63 @@ import { appRoutes } from "./routes/app";
 import { handleAssetRequest, initAssets } from "./services/assets";
 import { log } from "./services/logger";
 import { validateEnv } from "./utils/env";
+import { secureRoutes, withSecurityHeaders } from "./utils/security-headers";
 
 validateEnv();
 await runMigrations();
 await seedIfEmpty();
 await initAssets();
 
+// Fallback handler for everything not matched by a declared route. Returns a
+// bare Response; the `fetch` wrapper below decorates it with security headers.
+const handleFallback = async (req: Request): Promise<Response> => {
+  const url = new URL(req.url);
+
+  // Canonicalise trailing slashes: every path has exactly one URL. Requests
+  // for "/stack/" 308-redirect to "/stack" (preserving the query string) so
+  // crawlers never index duplicate slashed/unslashed variants.
+  if (url.pathname !== "/" && url.pathname.endsWith("/")) {
+    const canonical = url.pathname.replace(/\/+$/, "");
+    return new Response(null, {
+      status: 308,
+      headers: { Location: canonical + url.search },
+    });
+  }
+
+  // Lightweight liveness check for the platform healthcheck. Intentionally
+  // does not touch the DB — a transient DB blip should not cause the host to
+  // cycle the instance.
+  if (url.pathname === "/health") {
+    return new Response("ok", { status: 200 });
+  }
+
+  if (url.pathname.startsWith("/assets/")) {
+    const cached = handleAssetRequest(url);
+    if (cached) return cached;
+
+    const file = Bun.file(`dist${url.pathname}`);
+    if (await file.exists()) return new Response(file);
+    return new Response("Asset not found", { status: 404 });
+  }
+
+  if (url.pathname.startsWith("/")) {
+    const file = Bun.file(`public${url.pathname}`);
+    if (await file.exists()) return new Response(file);
+  }
+
+  return new Response("Not found", { status: 404 });
+};
+
 const server = Bun.serve({
   port: Number(process.env.PORT),
   idleTimeout: 30,
-  routes: {
+  routes: secureRoutes({
     ...appRoutes,
     ...adminRoutes,
     ...apiRoutes,
-  },
+  }),
   async fetch(req) {
-    const url = new URL(req.url);
-
-    // Canonicalise trailing slashes: every path has exactly one URL. Requests
-    // for "/stack/" 308-redirect to "/stack" (preserving the query string) so
-    // crawlers never index duplicate slashed/unslashed variants.
-    if (url.pathname !== "/" && url.pathname.endsWith("/")) {
-      const canonical = url.pathname.replace(/\/+$/, "");
-      return new Response(null, {
-        status: 308,
-        headers: { Location: canonical + url.search },
-      });
-    }
-
-    // Lightweight liveness check for the platform healthcheck. Intentionally
-    // does not touch the DB — a transient DB blip should not cause the host to
-    // cycle the instance.
-    if (url.pathname === "/health") {
-      return new Response("ok", { status: 200 });
-    }
-
-    if (url.pathname.startsWith("/assets/")) {
-      const cached = handleAssetRequest(url);
-      if (cached) return cached;
-
-      const file = Bun.file(`dist${url.pathname}`);
-      if (await file.exists()) return new Response(file);
-      return new Response("Asset not found", { status: 404 });
-    }
-
-    if (url.pathname.startsWith("/")) {
-      const file = Bun.file(`public${url.pathname}`);
-      if (await file.exists()) return new Response(file);
-    }
-
-    return new Response("Not found", { status: 404 });
+    return withSecurityHeaders(await handleFallback(req));
   },
 });
 

--- a/src/server/routes/app.tsx
+++ b/src/server/routes/app.tsx
@@ -1,10 +1,18 @@
-import { forms, home, projects, sitemap, stack } from "../controllers/app";
+import {
+  forms,
+  home,
+  projects,
+  securityTxt,
+  sitemap,
+  stack,
+} from "../controllers/app";
 import { callback, login, logout } from "../controllers/auth";
 import { createRouteHandler } from "../utils/route-handler";
 
 export const appRoutes = {
   "/": home.index,
   "/sitemap.xml": sitemap.index,
+  "/.well-known/security.txt": securityTxt.index,
   "/stack": stack.index,
   "/forms": createRouteHandler({
     GET: forms.index,

--- a/src/server/services/security-txt.test.ts
+++ b/src/server/services/security-txt.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { buildSecurityTxt } from "./security-txt";
+import { SITE_URL } from "./seo";
+
+const host = new URL(SITE_URL).host;
+
+describe("buildSecurityTxt", () => {
+  afterEach(() => {
+    delete process.env.SECURITY_CONTACT;
+  });
+
+  test("falls back to a host-derived mailto when SECURITY_CONTACT is unset", () => {
+    delete process.env.SECURITY_CONTACT;
+    expect(buildSecurityTxt()).toContain(`Contact: mailto:security@${host}`);
+  });
+
+  test("wraps a bare email from SECURITY_CONTACT in mailto:", () => {
+    process.env.SECURITY_CONTACT = "secops@acme.test";
+    expect(buildSecurityTxt()).toContain("Contact: mailto:secops@acme.test");
+  });
+
+  test("uses a mailto: URI from SECURITY_CONTACT verbatim", () => {
+    process.env.SECURITY_CONTACT = "mailto:secops@acme.test";
+    expect(buildSecurityTxt()).toContain("Contact: mailto:secops@acme.test");
+  });
+
+  test("uses an https: report-form URI verbatim", () => {
+    process.env.SECURITY_CONTACT = "https://acme.test/security/report";
+    expect(buildSecurityTxt()).toContain(
+      "Contact: https://acme.test/security/report",
+    );
+  });
+
+  test("always includes the required Expires and Canonical fields", () => {
+    const body = buildSecurityTxt();
+    expect(body).toMatch(/^Expires: .+$/m);
+    expect(body).toContain(`Canonical: ${SITE_URL}/.well-known/security.txt`);
+  });
+});

--- a/src/server/services/security-txt.ts
+++ b/src/server/services/security-txt.ts
@@ -1,0 +1,38 @@
+import { SITE_URL } from "./seo";
+
+// Builds the /.well-known/security.txt body per RFC 9116. Required fields are
+// Contact and Expires; the rest are optional hardening.
+
+const host = new URL(SITE_URL).host;
+
+// RFC 9116 requires Expires to be a single ISO 8601 timestamp roughly a year
+// out. Computed once at process start so it stays stable for a deploy's
+// lifetime, and refreshes on every restart so it never silently lapses.
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+export const SECURITY_TXT_EXPIRES = new Date(
+  Date.now() + ONE_YEAR_MS,
+).toISOString();
+
+// The Contact field comes from the SECURITY_CONTACT env var so it can be set
+// per environment without editing code. A bare email is wrapped in `mailto:`;
+// an already-qualified URI (mailto:, https:, tel:) is used verbatim. With no
+// env set, falls back to a placeholder derived from the site host — replace it
+// with a monitored mailbox or report-form URL before going live.
+const resolveContact = (): string => {
+  const configured = process.env.SECURITY_CONTACT?.trim();
+  if (!configured) {
+    return `mailto:security@${host}`;
+  }
+  return /^(mailto:|https:|tel:)/i.test(configured)
+    ? configured
+    : `mailto:${configured}`;
+};
+
+export const buildSecurityTxt = (): string =>
+  [
+    `Contact: ${resolveContact()}`,
+    `Expires: ${SECURITY_TXT_EXPIRES}`,
+    `Canonical: ${SITE_URL}/.well-known/security.txt`,
+    "Preferred-Languages: en",
+    "",
+  ].join("\n");

--- a/src/server/templates/home.tsx
+++ b/src/server/templates/home.tsx
@@ -17,10 +17,7 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
   >
     <section className="hero">
       <div className="hero-lottie" id="hero-lottie" />
-      <a
-        className="hero-announce"
-        href="https://github.com/alexpricedev/Billet/pull/33"
-      >
+      <a className="hero-announce" href="https://specification.website">
         <svg
           className="hero-announce-icon"
           xmlns="http://www.w3.org/2000/svg"
@@ -36,7 +33,9 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
         >
           <path d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4" />
         </svg>
-        <span className="hero-announce-text">New: hardened HTTP security</span>
+        <span className="hero-announce-text">
+          Built to the specification.website standard
+        </span>
         <span className="hero-announce-arrow" aria-hidden="true">
           →
         </span>

--- a/src/server/templates/home.tsx
+++ b/src/server/templates/home.tsx
@@ -34,7 +34,7 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
           <path d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4" />
         </svg>
         <span className="hero-announce-text">
-          Built to the specification.website standard
+          New: built to the specification.website standard
         </span>
         <span className="hero-announce-arrow" aria-hidden="true">
           →

--- a/src/server/templates/home.tsx
+++ b/src/server/templates/home.tsx
@@ -39,7 +39,7 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
           <path d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4" />
         </svg>
         <span className="hero-announce-text">
-          New: built to the <u>specification.website</u> standard
+          New: now built to the <u>specification.website</u> standard
         </span>
         <span className="hero-announce-arrow" aria-hidden="true">
           →

--- a/src/server/templates/home.tsx
+++ b/src/server/templates/home.tsx
@@ -34,7 +34,7 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
           <path d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4" />
         </svg>
         <span className="hero-announce-text">
-          New: built to the specification.website standard
+          New: built to the <u>specification.website</u> standard
         </span>
         <span className="hero-announce-arrow" aria-hidden="true">
           →

--- a/src/server/templates/home.tsx
+++ b/src/server/templates/home.tsx
@@ -191,7 +191,26 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
     </section>
 
     <section className="spec">
-      <h2>Built to a public standard</h2>
+      <div className="spec-header">
+        <svg
+          className="spec-icon"
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 21V7" />
+          <path d="m16 12 2 2 4-4" />
+          <path d="M22 6V4a1 1 0 0 0-1-1h-5a4 4 0 0 0-4 4 4 4 0 0 0-4-4H3a1 1 0 0 0-1 1v13a1 1 0 0 0 1 1h6a3 3 0 0 1 3 3 3 3 0 0 1 3-3h6a1 1 0 0 0 1-1v-1.3" />
+        </svg>
+        <h2>Built to a public standard</h2>
+      </div>
       <p className="spec-lead text-secondary">
         <a
           href="https://specification.website"

--- a/src/server/templates/home.tsx
+++ b/src/server/templates/home.tsx
@@ -19,7 +19,7 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
       <div className="hero-lottie" id="hero-lottie" />
       <a
         className="hero-announce"
-        href="https://github.com/alexpricedev/Billet/pull/31"
+        href="https://github.com/alexpricedev/Billet/pull/33"
       >
         <svg
           className="hero-announce-icon"
@@ -36,9 +36,7 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
         >
           <path d="M12 3q1 4 4 6.5t3 5.5a1 1 0 0 1-14 0 5 5 0 0 1 1-3 1 1 0 0 0 5 0c0-2-1.5-3-1.5-5q0-2 2.5-4" />
         </svg>
-        <span className="hero-announce-text">
-          New: first-class SEO defaults
-        </span>
+        <span className="hero-announce-text">New: hardened HTTP security</span>
         <span className="hero-announce-arrow" aria-hidden="true">
           →
         </span>
@@ -153,8 +151,8 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
         <div className="feature-card">
           <h3>Security</h3>
           <p>
-            CSRF protection, rate limiting, session fixation prevention,
-            security headers
+            CSRF protection, rate limiting, a Content Security Policy, HSTS, and
+            security headers on every response
           </p>
         </div>
         <div className="feature-card">
@@ -167,7 +165,7 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
         <div className="feature-card">
           <h3>Testing</h3>
           <p>
-            220+ tests, deterministic templates, real database testing, no
+            270+ tests, deterministic templates, real database testing, no
             browser simulation
           </p>
         </div>

--- a/src/server/templates/home.tsx
+++ b/src/server/templates/home.tsx
@@ -189,5 +189,64 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
         </div>
       </div>
     </section>
+
+    <section className="spec">
+      <h2>Built to a public standard</h2>
+      <p className="spec-lead text-secondary">
+        <a
+          href="https://specification.website"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          specification.website
+        </a>{" "}
+        is an open, platform-agnostic checklist of the technical features a good
+        website should have — 168 specs across foundations, SEO, accessibility,
+        security, performance, and more. Billet works through it section by
+        section, so the boring-but-critical baseline is in place before you
+        write a line of product code.
+      </p>
+      <div className="feedback-stack">
+        <div className="stack-row">
+          <span className="stack-layer">Foundations</span>
+          <span className="stack-catches">
+            Doctype, charset, viewport, canonical URLs, Open Graph, favicons,
+            theme-color
+          </span>
+        </div>
+        <div className="stack-row">
+          <span className="stack-layer">SEO</span>
+          <span className="stack-catches">
+            robots.txt, XML sitemap, JSON-LD, per-page metadata, an explicit
+            indexing policy
+          </span>
+        </div>
+        <div className="stack-row">
+          <span className="stack-layer">Accessibility</span>
+          <span className="stack-catches">
+            Semantic landmarks, labelled forms, focus rings, reduced motion,
+            captioned tables
+          </span>
+        </div>
+        <div className="stack-row">
+          <span className="stack-layer">Security</span>
+          <span className="stack-catches">
+            Security headers on every response, a Content Security Policy, HSTS,
+            security.txt, Subresource Integrity, Clear-Site-Data
+          </span>
+        </div>
+      </div>
+      <p className="spec-note text-tertiary">
+        Performance, privacy, resilience, and internationalisation are next.
+      </p>
+      <a
+        className="spec-cta"
+        href="https://specification.website"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Read the full standard <span aria-hidden="true">→</span>
+      </a>
+    </section>
   </Layout>
 );

--- a/src/server/templates/home.tsx
+++ b/src/server/templates/home.tsx
@@ -17,7 +17,12 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
   >
     <section className="hero">
       <div className="hero-lottie" id="hero-lottie" />
-      <a className="hero-announce" href="https://specification.website">
+      <a
+        className="hero-announce"
+        href="https://specification.website"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         <svg
           className="hero-announce-icon"
           xmlns="http://www.w3.org/2000/svg"

--- a/src/server/templates/stack.tsx
+++ b/src/server/templates/stack.tsx
@@ -56,7 +56,7 @@ export const Stack = ({ user, csrfToken }: StackProps) => (
 │   ├── templates/           # Full-page JSX templates
 │   ├── components/          # Reusable server JSX
 │   ├── services/            # Business logic & data
-│   ├── middleware/          # Auth, CSRF
+│   ├── middleware/          # Auth, CSRF, rate limiting
 │   ├── utils/               # Shared helpers
 │   └── database/            # Migrations
 │

--- a/src/server/utils/response.ts
+++ b/src/server/utils/response.ts
@@ -1,16 +1,14 @@
 import type { JSX } from "react";
 import { renderToString } from "react-dom/server";
 
-const securityHeaders: Record<string, string> = {
-  "X-Content-Type-Options": "nosniff",
-  "X-Frame-Options": "DENY",
-  "Referrer-Policy": "strict-origin-when-cross-origin",
-};
+// Security headers are applied centrally to every response — see
+// `secureRoutes` and the `fetch` fallback in main.ts — so producers here only
+// set content-specific headers.
 
 export const redirect = (url: string, status = 303) =>
   new Response("", { status, headers: { Location: url } });
 
 export const render = (element: JSX.Element): Response =>
   new Response(`<!DOCTYPE html>${renderToString(element)}`, {
-    headers: { "Content-Type": "text/html", ...securityHeaders },
+    headers: { "Content-Type": "text/html" },
   });

--- a/src/server/utils/security-headers.test.ts
+++ b/src/server/utils/security-headers.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { createBunRequest } from "../test-utils/bun-request";
+import {
+  SECURITY_HEADERS,
+  secureRoutes,
+  withSecurityHeaders,
+} from "./security-headers";
+
+describe("withSecurityHeaders", () => {
+  test("adds the core security headers to a bare response", () => {
+    const res = withSecurityHeaders(new Response("ok"));
+
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    expect(res.headers.get("Referrer-Policy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+    expect(res.headers.get("Cross-Origin-Opener-Policy")).toBe("same-origin");
+    expect(res.headers.get("Permissions-Policy")).toContain("camera=()");
+  });
+
+  test("sets a Content-Security-Policy with clickjacking and upgrade directives", () => {
+    const res = withSecurityHeaders(new Response("ok"));
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+
+    expect(csp).toContain("frame-ancestors 'none'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'none'");
+    expect(csp).toContain("upgrade-insecure-requests");
+  });
+
+  test("does not clobber headers a response already set", () => {
+    const res = withSecurityHeaders(
+      new Response("ok", {
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "public, max-age=60",
+        },
+      }),
+    );
+
+    expect(res.headers.get("Content-Type")).toBe("application/json");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  test("omits HSTS outside production", () => {
+    // Tests run with NODE_ENV=test, so the strict-transport header is withheld
+    // to avoid pinning localhost to HTTPS.
+    expect(SECURITY_HEADERS["Strict-Transport-Security"]).toBeUndefined();
+  });
+});
+
+describe("secureRoutes", () => {
+  test("decorates every handler's response with security headers", async () => {
+    const routes = secureRoutes({
+      "/thing": (_req) => new Response("thing"),
+    });
+
+    const req = createBunRequest("http://localhost:3000/thing");
+    const res = await routes["/thing"](req);
+
+    expect(await res.text()).toBe("thing");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(res.headers.get("Content-Security-Policy")).toContain(
+      "frame-ancestors 'none'",
+    );
+  });
+
+  test("awaits async handlers before decorating", async () => {
+    const routes = secureRoutes({
+      "/async": async (_req) => new Response("async"),
+    });
+
+    const req = createBunRequest("http://localhost:3000/async");
+    const res = await routes["/async"](req);
+
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+  });
+});

--- a/src/server/utils/security-headers.ts
+++ b/src/server/utils/security-headers.ts
@@ -1,0 +1,103 @@
+import type { BunRequest } from "bun";
+
+// Single source of truth for the security headers sent on every response —
+// HTML, JSON, redirects, static files, and errors alike. Applied centrally
+// (see `secureRoutes` and the `fetch` fallback in main.ts) rather than per
+// route, so no response path can accidentally ship without them.
+
+const isProduction = process.env.NODE_ENV === "production";
+
+// Content Security Policy. Enforcing, but deliberately host-allowlist based
+// rather than nonce + 'strict-dynamic': the page ships an inline importmap and
+// inline JSON-LD, and pulls Preact from esm.sh and lottie from unpkg. Those
+// inline blocks force 'unsafe-inline' here. The real wins this still buys:
+// frame-ancestors (clickjacking), object-src/base-uri lockdown, a tight source
+// allowlist, and upgrade-insecure-requests. Hardening to nonce + 'strict-dynamic'
+// (which lets us drop 'unsafe-inline') is the documented follow-up.
+const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "base-uri 'none'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "script-src 'self' 'unsafe-inline' https://unpkg.com https://esm.sh",
+  "connect-src 'self'",
+  "upgrade-insecure-requests",
+].join("; ");
+
+// Deny every powerful feature we do not use; fullscreen stays available to our
+// own origin. Mirrors the specification.website lock-down baseline.
+const PERMISSIONS_POLICY = [
+  "accelerometer=()",
+  "ambient-light-sensor=()",
+  "autoplay=()",
+  "battery=()",
+  "camera=()",
+  "display-capture=()",
+  "document-domain=()",
+  "encrypted-media=()",
+  "execution-while-not-rendered=()",
+  "execution-while-out-of-viewport=()",
+  "fullscreen=(self)",
+  "geolocation=()",
+  "gyroscope=()",
+  "keyboard-map=()",
+  "magnetometer=()",
+  "microphone=()",
+  "midi=()",
+  "navigation-override=()",
+  "payment=()",
+  "picture-in-picture=()",
+  "publickey-credentials-get=()",
+  "screen-wake-lock=()",
+  "sync-xhr=()",
+  "usb=()",
+  "web-share=()",
+  "xr-spatial-tracking=()",
+].join(", ");
+
+export const SECURITY_HEADERS: Record<string, string> = {
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Permissions-Policy": PERMISSIONS_POLICY,
+  "Content-Security-Policy": CONTENT_SECURITY_POLICY,
+  // HSTS only in production: sending it over plain HTTP in local dev would pin
+  // the browser to HTTPS for localhost. `preload` is safe here because
+  // includeSubDomains + a two-year max-age meet the preload-list requirements.
+  ...(isProduction
+    ? {
+        "Strict-Transport-Security":
+          "max-age=63072000; includeSubDomains; preload",
+      }
+    : {}),
+};
+
+// Merge the security headers onto an existing response without clobbering
+// headers a route already set (Content-Type, Cache-Control, Location, or an
+// intentional per-route override such as a relaxed CSP).
+export const withSecurityHeaders = (res: Response): Response => {
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+    if (!res.headers.has(name)) {
+      res.headers.set(name, value);
+    }
+  }
+  return res;
+};
+
+type RouteHandler = (req: BunRequest) => Response | Promise<Response>;
+
+// Wrap a Bun `routes` map so every handler's response is decorated with the
+// security headers before it leaves the server.
+export const secureRoutes = <T extends Record<string, RouteHandler>>(
+  routes: T,
+): T => {
+  const wrapped: Record<string, RouteHandler> = {};
+  for (const [path, handler] of Object.entries(routes)) {
+    wrapped[path] = async (req) => withSecurityHeaders(await handler(req));
+  }
+  return wrapped as T;
+};


### PR DESCRIPTION
Audits and remediates the specification.website **Security** section, refreshes the marketing pages to reflect the spec-alignment work, and documents CI merge-gating.

## Security hardening

- **Central security headers on every response** — new `utils/security-headers.ts`, applied via `secureRoutes` + a `fetch` wrapper in `main.ts`, replacing the three-header block that only covered HTML renders. Now covers JSON, static files, redirects, and errors: `nosniff`, `X-Frame-Options`, `Referrer-Policy`, `Cross-Origin-Opener-Policy`, a deny-all `Permissions-Policy`, an enforcing CSP (`frame-ancestors`/`object-src`/`base-uri 'none'` + `upgrade-insecure-requests`, allowlisting unpkg.com + esm.sh), and HSTS in production only.
- **`/.well-known/security.txt`** — served dynamically; `Contact` is env-driven via `SECURITY_CONTACT` with a host-derived fallback.
- **Subresource Integrity** — pins the lottie CDN script to `5.13.0` with a SHA-384 hash.
- **Clear-Site-Data on logout** — wipes cookies + client storage on sign-out.

## Home & stack pages

- New **"Built to a public standard"** section on the home page — an amber bordered box (matching the hero banner) detailing the specification.website categories covered (Foundations, SEO, Accessibility, Security), with a book-open-check icon and a link out.
- Repointed the hero banner to specification.website (opens in a new tab), broadened the Security feature card, bumped the test count, and corrected the stack page's middleware note.

## Docs

- New `runbooks/SECURITY.md` (headers, CSP, security.txt, SRI, TLS/HSTS-preload, CAA/DNSSEC) and `runbooks/CI.md` (the Actions pipeline + how to gate merges behind required status checks), linked from the README, START_PROMPT, `.env.example`, and the root SECURITY.md.

Tests added for the header layer, security.txt, and logout. Verified live in a browser (no CSP/SRI violations), with a clean `bun run check` and the full suite passing. Note: `main` branch protection was also enabled out-of-band to require these CI checks before merge (see `runbooks/CI.md`).