### PR TITLE
Make the site AI-assistant ready (llms.txt, robots.txt, discovery headers)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,0 @@
-User-agent: *
-Allow: /
-Disallow: /admin
-Disallow: /api/
-Disallow: /auth/
-
-Sitemap: https://billet.alexprice.dev/sitemap.xml

--- a/src/server/controllers/app/index.ts
+++ b/src/server/controllers/app/index.ts
@@ -1,6 +1,8 @@
 export { forms } from "./forms";
 export { home } from "./home";
+export { llmsTxt } from "./llms-txt";
 export { projects } from "./projects";
+export { robotsTxt } from "./robots-txt";
 export { securityTxt } from "./security-txt";
 export { sitemap } from "./sitemap";
 export { stack } from "./stack";

--- a/src/server/controllers/app/llms-txt.test.ts
+++ b/src/server/controllers/app/llms-txt.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { SITE_NAME } from "../../services/seo";
+import { llmsTxt } from "./llms-txt";
+
+describe("llms.txt Controller", () => {
+  test("serves markdown with the correct content type", async () => {
+    const response = llmsTxt.index();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/markdown; charset=utf-8",
+    );
+    expect(body).toStartWith(`# ${SITE_NAME}`);
+  });
+
+  test("sets a cache-control header", () => {
+    const response = llmsTxt.index();
+
+    expect(response.headers.get("cache-control")).toBe("public, max-age=3600");
+  });
+});

--- a/src/server/controllers/app/llms-txt.ts
+++ b/src/server/controllers/app/llms-txt.ts
@@ -1,0 +1,12 @@
+import { buildLlmsTxt } from "../../services/llms-txt";
+
+export const llmsTxt = {
+  index(): Response {
+    return new Response(buildLlmsTxt(), {
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Cache-Control": "public, max-age=3600",
+      },
+    });
+  },
+};

--- a/src/server/controllers/app/robots-txt.test.ts
+++ b/src/server/controllers/app/robots-txt.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { SITE_URL } from "../../services/seo";
+import { robotsTxt } from "./robots-txt";
+
+describe("robots.txt Controller", () => {
+  test("serves plain text with the correct content type", async () => {
+    const response = robotsTxt.index();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    expect(body).toContain("User-agent: *");
+    expect(body).toContain("Allow: /");
+  });
+
+  test("disallows private surfaces for every group", async () => {
+    const body = await robotsTxt.index().text();
+
+    expect(body).toContain("Disallow: /admin");
+    expect(body).toContain("Disallow: /api/");
+    expect(body).toContain("Disallow: /auth/");
+  });
+
+  test("calls out named AI crawlers explicitly", async () => {
+    const body = await robotsTxt.index().text();
+
+    expect(body).toContain("User-agent: GPTBot");
+    expect(body).toContain("User-agent: ClaudeBot");
+    expect(body).toContain("User-agent: Google-Extended");
+  });
+
+  test("declares an open Content-Signal posture", async () => {
+    const body = await robotsTxt.index().text();
+
+    expect(body).toContain(
+      "Content-Signal: search=yes, ai-input=yes, ai-train=yes",
+    );
+  });
+
+  test("points at the absolute sitemap URL under SITE_URL", async () => {
+    const body = await robotsTxt.index().text();
+
+    expect(body).toContain(`Sitemap: ${SITE_URL}/sitemap.xml`);
+  });
+});

--- a/src/server/controllers/app/robots-txt.ts
+++ b/src/server/controllers/app/robots-txt.ts
@@ -1,0 +1,12 @@
+import { buildRobotsTxt } from "../../services/seo";
+
+export const robotsTxt = {
+  index(): Response {
+    return new Response(buildRobotsTxt(), {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "public, max-age=3600",
+      },
+    });
+  },
+};

--- a/src/server/routes/app.tsx
+++ b/src/server/routes/app.tsx
@@ -1,7 +1,9 @@
 import {
   forms,
   home,
+  llmsTxt,
   projects,
+  robotsTxt,
   securityTxt,
   sitemap,
   stack,
@@ -11,7 +13,9 @@ import { createRouteHandler } from "../utils/route-handler";
 
 export const appRoutes = {
   "/": home.index,
+  "/robots.txt": robotsTxt.index,
   "/sitemap.xml": sitemap.index,
+  "/llms.txt": llmsTxt.index,
   "/.well-known/security.txt": securityTxt.index,
   "/stack": stack.index,
   "/forms": createRouteHandler({

--- a/src/server/services/llms-txt.test.ts
+++ b/src/server/services/llms-txt.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { buildLlmsTxt } from "./llms-txt";
+import { SITE_NAME, SITE_URL, SITEMAP_PATHS } from "./seo";
+
+describe("buildLlmsTxt", () => {
+  test("opens with the H1 site name and a blockquote summary", () => {
+    const body = buildLlmsTxt();
+
+    expect(body).toStartWith(`# ${SITE_NAME}\n`);
+    expect(body).toMatch(/^> .+/m);
+  });
+
+  test("groups links under Pages and Resources headings", () => {
+    const body = buildLlmsTxt();
+
+    expect(body).toContain("## Pages");
+    expect(body).toContain("## Resources");
+  });
+
+  test("lists every public sitemap path as an absolute markdown link", () => {
+    const body = buildLlmsTxt();
+
+    for (const path of SITEMAP_PATHS) {
+      const href = new URL(path, SITE_URL).href;
+      expect(body).toContain(`](${href}):`);
+    }
+  });
+
+  test("points agents at the sitemap and security policy resources", () => {
+    const body = buildLlmsTxt();
+
+    expect(body).toContain(`${SITE_URL}/sitemap.xml`);
+    expect(body).toContain(`${SITE_URL}/.well-known/security.txt`);
+  });
+});

--- a/src/server/services/llms-txt.ts
+++ b/src/server/services/llms-txt.ts
@@ -1,0 +1,78 @@
+import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "./seo";
+
+// Builds the /llms.txt body — the emerging convention that gives LLMs and AI
+// agents a short, curated markdown index of the site. Unlike the sitemap (an
+// exhaustive machine list of URLs), this is a hand-written summary with a
+// one-line description per page. It controls nothing; it is purely a hint.
+//
+// The page list is kept in sync with the public routes by a drift test in
+// llms-txt.test.ts, so a new public page can't silently go unlisted.
+
+interface LlmsPage {
+  path: string;
+  title: string;
+  description: string;
+}
+
+const PAGES: LlmsPage[] = [
+  {
+    path: "/",
+    title: "Home",
+    description:
+      "Overview of the Billet stack and the production web defaults it ships out of the box.",
+  },
+  {
+    path: "/stack",
+    title: "The Stack",
+    description:
+      "The technologies and architecture Billet is built on — Bun, server-rendered JSX, PostgreSQL, and Preact islands.",
+  },
+  {
+    path: "/forms",
+    title: "Forms",
+    description:
+      "Server-rendered form handling with validation, CSRF protection, and progressive enhancement.",
+  },
+  {
+    path: "/projects",
+    title: "Projects",
+    description:
+      "A CRUD example backed by a shared service layer, exposed as both HTML pages and a JSON API.",
+  },
+];
+
+const RESOURCES: LlmsPage[] = [
+  {
+    path: "/sitemap.xml",
+    title: "Sitemap",
+    description: "XML sitemap of every public page.",
+  },
+  {
+    path: "/.well-known/security.txt",
+    title: "Security policy",
+    description: "How to report a security vulnerability (RFC 9116).",
+  },
+];
+
+const absolute = (path: string): string => new URL(path, SITE_URL).href;
+
+const linkLine = ({ path, title, description }: LlmsPage): string =>
+  `- [${title}](${absolute(path)}): ${description}`;
+
+export const buildLlmsTxt = (): string =>
+  [
+    `# ${SITE_NAME}`,
+    "",
+    `> ${SITE_DESCRIPTION}`,
+    "",
+    "Billet is a server-rendered TypeScript web app (Bun with JSX templates, no client framework) that ships correct web defaults — foundations, SEO, accessibility, security, and agent readiness — so coding agents can build features on a solid baseline.",
+    "",
+    "## Pages",
+    "",
+    ...PAGES.map(linkLine),
+    "",
+    "## Resources",
+    "",
+    ...RESOURCES.map(linkLine),
+    "",
+  ].join("\n");

--- a/src/server/services/seo.ts
+++ b/src/server/services/seo.ts
@@ -25,6 +25,54 @@ ${urls}
 `;
 };
 
+// Named AI crawlers we call out explicitly in robots.txt so the allow posture
+// is unambiguous rather than only implied by the wildcard group. In robots.txt
+// a named user-agent group fully replaces the wildcard for that agent, so each
+// named group repeats the same Disallow rules.
+const AI_CRAWLERS = [
+  "GPTBot",
+  "OAI-SearchBot",
+  "ChatGPT-User",
+  "ClaudeBot",
+  "Claude-Web",
+  "Google-Extended",
+  "Applebot-Extended",
+  "PerplexityBot",
+  "CCBot",
+] as const;
+
+// Private surfaces kept out of every crawler's reach.
+const ROBOTS_DISALLOW = ["/admin", "/api/", "/auth/"] as const;
+
+// Content-Signal (an emerging IETF AI Preferences / IAB Tech Lab proposal)
+// declares downstream-use consent explicitly for crawlers that honour it.
+const CONTENT_SIGNAL = "Content-Signal: search=yes, ai-input=yes, ai-train=yes";
+
+// Builds the /robots.txt body. Billet is designed to be built on by AI coding
+// agents, so the posture is deliberately open: search engines and the major AI
+// crawlers are all allowed, with only private surfaces disallowed.
+export const buildRobotsTxt = (): string => {
+  const group = (agents: readonly string[]): string =>
+    [
+      ...agents.map((agent) => `User-agent: ${agent}`),
+      "Allow: /",
+      ...ROBOTS_DISALLOW.map((path) => `Disallow: ${path}`),
+      CONTENT_SIGNAL,
+    ].join("\n");
+
+  return [
+    "# Billet is designed to be built on by AI coding agents, so search engines",
+    "# and AI crawlers are welcome. Only private surfaces are disallowed.",
+    "",
+    group(["*"]),
+    "",
+    group(AI_CRAWLERS),
+    "",
+    `Sitemap: ${absolute("/sitemap.xml")}`,
+    "",
+  ].join("\n");
+};
+
 // Site-level JSON-LD (WebSite + Organization) injected into every public page's
 // <head>. Gives search engines and AI agents a machine-readable description of
 // the site using the schema.org vocabulary.

--- a/src/server/templates/home.tsx
+++ b/src/server/templates/home.tsx
@@ -254,6 +254,14 @@ export const Home = ({ user, csrfToken }: HomeProps) => (
             security.txt, Subresource Integrity, Clear-Site-Data
           </span>
         </div>
+        <div className="stack-row">
+          <span className="stack-layer">Agent readiness</span>
+          <span className="stack-catches">
+            An llms.txt index, AI-crawler rules and Content-Signal in
+            robots.txt, machine-readable Link headers, structured data, stable
+            URLs
+          </span>
+        </div>
       </div>
       <p className="spec-note text-tertiary">
         Performance, privacy, resilience, and internationalisation are next.

--- a/src/server/utils/security-headers.test.ts
+++ b/src/server/utils/security-headers.test.ts
@@ -29,6 +29,23 @@ describe("withSecurityHeaders", () => {
     expect(csp).toContain("upgrade-insecure-requests");
   });
 
+  test("advertises discovery resources via a Link header", () => {
+    const res = withSecurityHeaders(new Response("ok"));
+    const link = res.headers.get("Link") ?? "";
+
+    expect(link).toContain('</llms.txt>; rel="describedby"');
+    expect(link).toContain('</sitemap.xml>; rel="sitemap"');
+    expect(link).toContain('</.well-known/security.txt>; rel="security"');
+  });
+
+  test("does not clobber a Link header a response already set", () => {
+    const res = withSecurityHeaders(
+      new Response("ok", { headers: { Link: "<https://x.test>; rel=next" } }),
+    );
+
+    expect(res.headers.get("Link")).toBe("<https://x.test>; rel=next");
+  });
+
   test("does not clobber headers a response already set", () => {
     const res = withSecurityHeaders(
       new Response("ok", {

--- a/src/server/utils/security-headers.ts
+++ b/src/server/utils/security-headers.ts
@@ -58,6 +58,17 @@ const PERMISSIONS_POLICY = [
   "xr-spatial-tracking=()",
 ].join(", ");
 
+// Discovery Link header — advertises the site's machine-readable resources on
+// every response so agents and crawlers that never parse our HTML can still
+// find them (see spec: agent-readiness/link-headers). Relative refs resolve
+// against the request URL, keeping this host-agnostic. All rel values are
+// IANA-registered: `describedby`, `sitemap`, and `security` (RFC 9116).
+export const DISCOVERY_LINK_HEADER = [
+  '</llms.txt>; rel="describedby"; type="text/markdown"',
+  '</sitemap.xml>; rel="sitemap"; type="application/xml"',
+  '</.well-known/security.txt>; rel="security"; type="text/plain"',
+].join(", ");
+
 export const SECURITY_HEADERS: Record<string, string> = {
   "X-Content-Type-Options": "nosniff",
   "X-Frame-Options": "DENY",
@@ -84,6 +95,10 @@ export const withSecurityHeaders = (res: Response): Response => {
     if (!res.headers.has(name)) {
       res.headers.set(name, value);
     }
+  }
+  // Advertise discovery resources unless a route set its own Link header.
+  if (!res.headers.has("Link")) {
+    res.headers.set("Link", DISCOVERY_LINK_HEADER);
   }
   return res;
 };


### PR DESCRIPTION
## 🤖 What this does, in plain terms

More and more visitors to a website aren't people — they're AI assistants like ChatGPT and Claude, plus search engines. This change puts up clear **signposts** so those automated visitors can understand the site, know what they're allowed to read, and find their way around. There's no change or downside for human visitors.

## ✨ What changed

| Change | In plain English |
| --- | --- |
| **A summary page for AI** (`/llms.txt`) | A short, plain-English overview of the site with links to the main pages — like a welcome note written for AI tools. |
| **Clear rules for AI crawlers** (`robots.txt`) | The site now explicitly welcomes the major AI crawlers and states how its content may be used, while keeping private areas (admin, login) off-limits. |
| **Signposts on every page** (discovery headers) | Every page quietly points visitors to the site map, the AI summary, and the security-contact details. |
| **Homepage update** | The "Built to a public standard" section now shows **Agent readiness** alongside Foundations, SEO, Accessibility, and Security. |

## 🎯 Why it matters

As AI assistants become a bigger source of traffic, these signposts help them describe the site accurately and send the right visitors our way. It's part of Billet working through the public [specification.website](https://specification.website) standard, section by section.

## ✅ Safety & testing

- All **286 automated tests pass**, including new tests covering each addition.
- No private information is exposed — private areas stay blocked as before.
- Passes the project's strict linting and type checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)