### PR TITLE
Resilience: 404/500/503 pages, dynamic web app manifest, X-Redirect-By

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,11 @@ FROM_NAME=Billet
 
 # Required when EMAIL_PROVIDER=resend
 # RESEND_API_KEY=re_your_key_here
+
+# Optional — set to "true" to serve a 503 "under maintenance" page (with a
+# Retry-After header) for every request except the /health check. An app-level
+# fallback; prefer flipping maintenance at your edge/CDN when you can, since the
+# app is what you're taking offline. MAINTENANCE_RETRY_AFTER overrides the
+# Retry-After value in seconds (default 3600).
+# MAINTENANCE_MODE=true
+# MAINTENANCE_RETRY_AFTER=3600

--- a/START_PROMPT.md
+++ b/START_PROMPT.md
@@ -57,6 +57,8 @@ Replace **Billet** with the chosen project name across the codebase. This is a c
 
 > **Note:** `src/server/services/seo.ts` also defines `SITE_URL` (currently `https://billet.alexprice.dev`), the canonical origin used for `<link rel="canonical">`, Open Graph tags, the XML sitemap, and JSON-LD across every page. `public/robots.txt` has a matching hardcoded `Sitemap:` URL. Point both at your own production domain before deploying — see [runbooks/SEO.md](runbooks/SEO.md) §1.
 
+> **Note:** `SITE_NAME` also feeds the web app manifest (`/site.webmanifest` — the installed-app name/short name, built by `buildWebManifest()` in `seo.ts`) and the `X-Redirect-By` response header stamped on every redirect. Both are generated from that one constant, so renaming `SITE_NAME` renames them automatically — "Billet" never gets stuck in the installed-app name or redirect attribution. The manifest still references the icon files in `public/` (`android-chrome-192x192.png`, `android-chrome-512x512.png`, favicons, `apple-touch-icon.png`); swap those for your own artwork, and for a crisp Android adaptive icon provide a safe-zone-padded maskable variant (the 512px icon is reused as the maskable one by default).
+
 ## 3. Remove original repo references
 
 These are links specific to the original Billet repository. Remove or update them:

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,0 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#0a0a0b","background_color":"#0a0a0b","display":"standalone"}

--- a/src/client/pages/error.css
+++ b/src/client/pages/error.css
@@ -1,0 +1,50 @@
+[data-page="error"] {
+  & > main {
+    text-align: center;
+  }
+
+  .error-page {
+    margin: 0 auto;
+    max-width: 32rem;
+    padding-block: 3rem;
+  }
+
+  .error-status {
+    color: var(--color-text-quaternary);
+    font-size: 3rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    line-height: 1;
+    margin: 0;
+  }
+
+  .error-page h1 {
+    margin-top: 0.5rem;
+  }
+
+  .error-actions {
+    margin-top: 2rem;
+  }
+
+  /* .btn-primary is scoped to the home hero, so give the error CTA the same
+     filled-primary treatment here (it's an anchor, not a <button>). */
+  .error-actions .btn-primary {
+    align-items: center;
+    background: var(--color-primary);
+    border-radius: var(--radius);
+    color: #fff;
+    display: inline-flex;
+    font-size: 14px;
+    font-weight: 500;
+    padding: 10px 22px;
+    text-decoration: none;
+    transition: all 150ms ease;
+
+    &:hover,
+    &:focus {
+      background: var(--color-primary-hover);
+      color: #fff;
+      text-decoration: none;
+    }
+  }
+}

--- a/src/client/style.css
+++ b/src/client/style.css
@@ -5,6 +5,7 @@
 @import "./pages/projects.css";
 @import "./pages/login.css";
 @import "./pages/admin.css";
+@import "./pages/error.css";
 
 /* Component styles */
 @import "./components/layout.css";

--- a/src/server/components/layouts.tsx
+++ b/src/server/components/layouts.tsx
@@ -3,6 +3,7 @@ import type React from "react";
 import { getAssetUrl } from "../services/assets";
 import {
   SITE_DESCRIPTION,
+  SITE_NAME,
   SITE_URL,
   siteStructuredData,
 } from "../services/seo";
@@ -151,12 +152,7 @@ export function Layout({
           <Nav page={name} user={user} csrfToken={csrfToken} />
         </header>
         <main>{children}</main>
-        <footer>
-          <a href="https://github.com/alexpricedev/Billet">GitHub</a>
-          <span>
-            Built by <a href="https://alexprice.dev">alexprice.dev</a>
-          </span>
-        </footer>
+        <SiteFooter />
         <script
           async
           src="https://unpkg.com/lottie-web@5.13.0/build/player/lottie_light.min.js"
@@ -164,6 +160,52 @@ export function Layout({
           crossOrigin="anonymous"
         />
         <script type="module" src={getAssetUrl("/assets/main.js")} />
+      </body>
+    </html>
+  );
+}
+
+// Shared site footer for the full Layout and the ErrorLayout, so the repo-specific
+// links (see START_PROMPT.md §3) live in one place.
+function SiteFooter() {
+  return (
+    <footer>
+      <a href="https://github.com/alexpricedev/Billet">GitHub</a>
+      <span>
+        Built by <a href="https://alexprice.dev">alexprice.dev</a>
+      </span>
+    </footer>
+  );
+}
+
+interface ErrorLayoutProps {
+  title: string;
+  children: React.ReactNode;
+  nav?: boolean;
+}
+
+// Layout for error and maintenance pages (404, 500, 503). Deliberately ships NO
+// client JavaScript — no importmap, Lottie, or main bundle — so the page renders
+// instantly and stays legible even when the app is degraded or offline, the
+// spec's resilience baseline for error and 503 responses. Reuses the same
+// header/footer chrome as `Layout` for continuity, and is always noindex so
+// crawlers never treat an error body as real content.
+export function ErrorLayout({ title, children, nav = true }: ErrorLayoutProps) {
+  return (
+    <html lang="en" style={{ colorScheme: "dark" }}>
+      <head>
+        <HeadMeta title={title} description={SITE_DESCRIPTION} noindex />
+      </head>
+      <body data-page="error" data-component="layout">
+        <header>
+          <a href="/" className="logo">
+            <Logo />
+            <span>{SITE_NAME}</span>
+          </a>
+          {nav && <Nav page="" user={null} />}
+        </header>
+        <main>{children}</main>
+        <SiteFooter />
       </body>
     </html>
   );

--- a/src/server/controllers/app/index.ts
+++ b/src/server/controllers/app/index.ts
@@ -6,3 +6,4 @@ export { robotsTxt } from "./robots-txt";
 export { securityTxt } from "./security-txt";
 export { sitemap } from "./sitemap";
 export { stack } from "./stack";
+export { webmanifest } from "./webmanifest";

--- a/src/server/controllers/app/webmanifest.test.ts
+++ b/src/server/controllers/app/webmanifest.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { SITE_NAME } from "../../services/seo";
+import { webmanifest } from "./webmanifest";
+
+describe("webmanifest Controller", () => {
+  test("serves the manifest with the installable media type", () => {
+    const response = webmanifest.index();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/manifest+json",
+    );
+  });
+
+  test("names the app from SITE_NAME so a fork is never stuck as Billet", async () => {
+    const manifest = await webmanifest.index().json();
+
+    expect(manifest.name).toBe(SITE_NAME);
+    expect(manifest.short_name).toBe(SITE_NAME);
+  });
+
+  test("declares the fields browsers need for installability", async () => {
+    const manifest = await webmanifest.index().json();
+
+    expect(manifest.start_url).toBe("/");
+    expect(manifest.display).toBe("standalone");
+    expect(manifest.theme_color).toBeTruthy();
+    expect(manifest.background_color).toBeTruthy();
+  });
+
+  test("ships 192 and 512 icons plus a maskable variant", async () => {
+    const manifest = await webmanifest.index().json();
+    const sizes = manifest.icons.map((icon: { sizes: string }) => icon.sizes);
+    const purposes = manifest.icons.map(
+      (icon: { purpose?: string }) => icon.purpose,
+    );
+
+    expect(sizes).toContain("192x192");
+    expect(sizes).toContain("512x512");
+    expect(purposes).toContain("maskable");
+  });
+});

--- a/src/server/controllers/app/webmanifest.ts
+++ b/src/server/controllers/app/webmanifest.ts
@@ -1,0 +1,14 @@
+import { buildWebManifest } from "../../services/seo";
+
+export const webmanifest = {
+  index(): Response {
+    return new Response(buildWebManifest(), {
+      headers: {
+        // The IANA-registered media type for a web app manifest. Browsers only
+        // treat the file as installable when served with this type.
+        "Content-Type": "application/manifest+json",
+        "Cache-Control": "public, max-age=3600",
+      },
+    });
+  },
+};

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -6,8 +6,13 @@ import { appRoutes } from "./routes/app";
 import { initAssets } from "./services/assets";
 import { log } from "./services/logger";
 import { validateEnv } from "./utils/env";
+import { render500 } from "./utils/errors";
 import { handleFallback } from "./utils/fallback";
-import { finalizeResponse, secureRoutes } from "./utils/security-headers";
+import {
+  handleGuarded,
+  secureRoutes,
+  withSecurityHeaders,
+} from "./utils/security-headers";
 
 validateEnv();
 await runMigrations();
@@ -23,7 +28,18 @@ const server = Bun.serve({
     ...apiRoutes,
   }),
   async fetch(req) {
-    return finalizeResponse(req, await handleFallback(req));
+    return handleGuarded(req, handleFallback);
+  },
+  // Last-resort backstop for anything the guarded pipeline doesn't catch (e.g.
+  // an error thrown in routing itself). Overriding Bun's default also stops its
+  // dev error page — which can leak a stack trace — from ever being served. No
+  // request is available here, so headers are stamped without compression.
+  error() {
+    try {
+      return withSecurityHeaders(render500());
+    } catch {
+      return new Response("Internal Server Error", { status: 500 });
+    }
   },
 });
 

--- a/src/server/routes/app.tsx
+++ b/src/server/routes/app.tsx
@@ -7,6 +7,7 @@ import {
   securityTxt,
   sitemap,
   stack,
+  webmanifest,
 } from "../controllers/app";
 import { callback, login, logout } from "../controllers/auth";
 import { createRouteHandler } from "../utils/route-handler";
@@ -14,6 +15,7 @@ import { createRouteHandler } from "../utils/route-handler";
 export const appRoutes = {
   "/": home.index,
   "/robots.txt": robotsTxt.index,
+  "/site.webmanifest": webmanifest.index,
   "/sitemap.xml": sitemap.index,
   "/llms.txt": llmsTxt.index,
   "/.well-known/security.txt": securityTxt.index,

--- a/src/server/services/seo.ts
+++ b/src/server/services/seo.ts
@@ -73,6 +73,44 @@ export const buildRobotsTxt = (): string => {
   ].join("\n");
 };
 
+// Web app manifest (spec: resilience/pwa-manifest). `name`/`short_name` follow
+// SITE_NAME so a fork is never stuck advertising "Billet" as its installed-app
+// name — updating the one constant renames it everywhere. Colours match the
+// dark theme (--color-bg in style.css / THEME_COLOR in layouts.tsx). The 512px
+// icon doubles as the maskable icon; swap in a purpose-built, safe-zone-padded
+// asset if you need edge-to-edge Android adaptive icons.
+export const buildWebManifest = (): string =>
+  JSON.stringify({
+    name: SITE_NAME,
+    short_name: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    start_url: "/",
+    scope: "/",
+    display: "standalone",
+    theme_color: "#0a0a0b",
+    background_color: "#0a0a0b",
+    icons: [
+      {
+        src: "/android-chrome-192x192.png",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/android-chrome-512x512.png",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/android-chrome-512x512.png",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "maskable",
+      },
+    ],
+  });
+
 // Site-level JSON-LD (WebSite + Organization) injected into every public page's
 // <head>. Gives search engines and AI agents a machine-readable description of
 // the site using the schema.org vocabulary.

--- a/src/server/templates/error.tsx
+++ b/src/server/templates/error.tsx
@@ -1,0 +1,38 @@
+import { ErrorLayout } from "@server/components/layouts";
+import { SITE_NAME } from "@server/services/seo";
+
+interface ErrorPageProps {
+  status: number;
+  heading: string;
+  message: string;
+  // 503 maintenance drops the nav (its links would only 503 too) and the home
+  // button (the site is intentionally offline).
+  showHome?: boolean;
+  nav?: boolean;
+}
+
+// A plain-language error page: the status, a human heading, an explanation that
+// never leaks implementation details, and a way forward. Rendered without any
+// client JS via ErrorLayout.
+export const ErrorPage = ({
+  status,
+  heading,
+  message,
+  showHome = true,
+  nav = true,
+}: ErrorPageProps) => (
+  <ErrorLayout title={`${heading} · ${SITE_NAME}`} nav={nav}>
+    <section className="error-page">
+      <p className="error-status">{status}</p>
+      <h1>{heading}</h1>
+      <p className="lead">{message}</p>
+      {showHome && (
+        <p className="error-actions">
+          <a className="btn-primary" href="/">
+            Back to homepage
+          </a>
+        </p>
+      )}
+    </section>
+  </ErrorLayout>
+);

--- a/src/server/utils/errors.test.tsx
+++ b/src/server/utils/errors.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { render404, render500, render503 } from "./errors";
+
+describe("error responses", () => {
+  test("render404 returns a 404 HTML page with a way forward and no leaks", async () => {
+    const res = render404();
+    const body = await res.text();
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+    expect(body).toContain("<!DOCTYPE html>");
+    expect(body).toContain("Page not found");
+    expect(body).toContain('href="/"');
+    // noindex so search engines never treat the error body as real content.
+    expect(body).toContain("noindex");
+  });
+
+  test("render500 returns a 500 HTML page with a generic, non-leaky message", async () => {
+    const res = render500();
+    const body = await res.text();
+
+    expect(res.status).toBe(500);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+    expect(body).toContain("Something went wrong");
+  });
+
+  test("render503 returns a 503 with Retry-After and no home/nav affordances", async () => {
+    const res = render503(1800);
+    const body = await res.text();
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("1800");
+    expect(body).toContain("be right back");
+    // The site is intentionally offline, so no "back to homepage" button.
+    expect(body).not.toContain("Back to homepage");
+  });
+});

--- a/src/server/utils/errors.tsx
+++ b/src/server/utils/errors.tsx
@@ -1,0 +1,56 @@
+import type { JSX } from "react";
+import { renderToString } from "react-dom/server";
+import { ErrorPage } from "../templates/error";
+
+// Renders an error template to a bare HTML Response. Callers pass it through
+// `finalizeResponse` (compression + security headers) before it leaves the
+// server, exactly like every other response.
+const renderError = (
+  element: JSX.Element,
+  status: number,
+  extraHeaders: Record<string, string> = {},
+): Response =>
+  new Response(`<!DOCTYPE html>${renderToString(element)}`, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8", ...extraHeaders },
+  });
+
+// 404 — the requested resource does not exist. Correct status (never a soft 200),
+// with site navigation and a homepage link as the way forward.
+export const render404 = (): Response =>
+  renderError(
+    <ErrorPage
+      status={404}
+      heading="Page not found"
+      message="We couldn't find the page you were looking for. It may have moved, or it may never have existed."
+    />,
+    404,
+  );
+
+// 500 — an unexpected server failure. Deliberately vague: no stack traces,
+// framework names, or paths reach the user.
+export const render500 = (): Response =>
+  renderError(
+    <ErrorPage
+      status={500}
+      heading="Something went wrong"
+      message="An unexpected error occurred on our end. Please try again in a moment — if it keeps happening, come back a little later."
+    />,
+    500,
+  );
+
+// 503 — the site is intentionally offline for maintenance. Includes a
+// Retry-After header so clients and crawlers know when to return, and drops the
+// nav/home affordances since every route is offline.
+export const render503 = (retryAfterSeconds: number): Response =>
+  renderError(
+    <ErrorPage
+      status={503}
+      heading="We'll be right back"
+      message="The site is offline for scheduled maintenance. Please check back shortly."
+      showHome={false}
+      nav={false}
+    />,
+    503,
+    { "Retry-After": String(retryAfterSeconds) },
+  );

--- a/src/server/utils/fallback.test.ts
+++ b/src/server/utils/fallback.test.ts
@@ -39,10 +39,14 @@ describe("handleFallback", () => {
     expect(await res.text()).toBe("Asset not found");
   });
 
-  test("returns 404 for an unknown path", async () => {
-    const res = await req("/nope/not-a-real-file.txt");
+  test("returns a styled HTML 404 page for an unknown path", async () => {
+    const res = await req("/nope/not-a-real-file");
 
     expect(res.status).toBe(404);
-    expect(await res.text()).toBe("Not found");
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+    const body = await res.text();
+    expect(body).toContain("Page not found");
+    // No implementation detail leaks and the page offers a way forward.
+    expect(body).toContain('href="/"');
   });
 });

--- a/src/server/utils/fallback.ts
+++ b/src/server/utils/fallback.ts
@@ -1,4 +1,5 @@
 import { handleAssetRequest } from "../services/assets";
+import { render404 } from "./errors";
 import { serveFile } from "./static-files";
 
 // Catch-all handler for requests not matched by a declared route: trailing-slash
@@ -41,5 +42,6 @@ export const handleFallback = async (req: Request): Promise<Response> => {
     if (await file.exists()) return serveFile(req, file);
   }
 
-  return new Response("Not found", { status: 404 });
+  // No route, no static file: a real 404 with the styled, navigable error page.
+  return render404();
 };

--- a/src/server/utils/maintenance.ts
+++ b/src/server/utils/maintenance.ts
@@ -1,0 +1,26 @@
+import { render503 } from "./errors";
+
+// App-level maintenance mode. Set MAINTENANCE_MODE=true to serve a 503 "we'll be
+// right back" page (with Retry-After) for every request. Intended as a fallback
+// — prefer flipping maintenance at your edge/CDN when you can, since the app is
+// what you're taking offline. MAINTENANCE_RETRY_AFTER overrides the default
+// Retry-After (seconds).
+const DEFAULT_RETRY_AFTER_SECONDS = 3600;
+
+// Returns a 503 response when maintenance mode is on, otherwise null so the
+// request continues normally. The platform health check is exempt so the host
+// doesn't cycle the instance while it's intentionally serving 503s.
+export const maintenanceResponse = (req: Request): Response | null => {
+  if (process.env.MAINTENANCE_MODE !== "true") return null;
+
+  const { pathname } = new URL(req.url);
+  if (pathname === "/health") return null;
+
+  const configured = Number(process.env.MAINTENANCE_RETRY_AFTER);
+  const retryAfter =
+    Number.isFinite(configured) && configured > 0
+      ? configured
+      : DEFAULT_RETRY_AFTER_SECONDS;
+
+  return render503(retryAfter);
+};

--- a/src/server/utils/security-headers.test.ts
+++ b/src/server/utils/security-headers.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { SITE_NAME } from "../services/seo";
 import { createBunRequest } from "../test-utils/bun-request";
 import {
+  handleGuarded,
   SECURITY_HEADERS,
   secureRoutes,
   withSecurityHeaders,
@@ -65,6 +67,88 @@ describe("withSecurityHeaders", () => {
     // Tests run with NODE_ENV=test, so the strict-transport header is withheld
     // to avoid pinning localhost to HTTPS.
     expect(SECURITY_HEADERS["Strict-Transport-Security"]).toBeUndefined();
+  });
+
+  test("signs a redirect with X-Redirect-By", () => {
+    const res = withSecurityHeaders(
+      new Response(null, { status: 308, headers: { Location: "/canonical" } }),
+    );
+
+    expect(res.headers.get("X-Redirect-By")).toBe(SITE_NAME);
+  });
+
+  test("does not add X-Redirect-By to a non-redirect response", () => {
+    const res = withSecurityHeaders(new Response("ok"));
+
+    expect(res.headers.get("X-Redirect-By")).toBeNull();
+  });
+});
+
+describe("handleGuarded", () => {
+  test("serves a styled 500 without leaking the error when the producer throws", async () => {
+    const req = createBunRequest("http://localhost:3000/boom");
+    const res = await handleGuarded(req, () => {
+      throw new Error("db exploded at /secret/path.ts:42");
+    });
+
+    expect(res.status).toBe(500);
+    expect(res.headers.get("Content-Type")).toContain("text/html");
+    const body = await res.text();
+    expect(body).toContain("Something went wrong");
+    expect(body).not.toContain("db exploded");
+    // Still runs through the header pipeline.
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  test("passes a successful response through unchanged", async () => {
+    const req = createBunRequest("http://localhost:3000/ok");
+    const res = await handleGuarded(req, () => new Response("hi"));
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("hi");
+  });
+
+  test("serves a 503 with Retry-After when maintenance mode is on", async () => {
+    const previous = process.env.MAINTENANCE_MODE;
+    process.env.MAINTENANCE_MODE = "true";
+    try {
+      const req = createBunRequest("http://localhost:3000/anything");
+      const res = await handleGuarded(
+        req,
+        () => new Response("should not run"),
+      );
+
+      expect(res.status).toBe(503);
+      expect(res.headers.get("Retry-After")).toBe("3600");
+      expect(await res.text()).toContain("be right back");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.MAINTENANCE_MODE;
+      } else {
+        process.env.MAINTENANCE_MODE = previous;
+      }
+    }
+  });
+
+  test("keeps the health check alive during maintenance", async () => {
+    const previous = process.env.MAINTENANCE_MODE;
+    process.env.MAINTENANCE_MODE = "true";
+    try {
+      const req = createBunRequest("http://localhost:3000/health");
+      const res = await handleGuarded(
+        req,
+        () => new Response("ok", { status: 200 }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("ok");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.MAINTENANCE_MODE;
+      } else {
+        process.env.MAINTENANCE_MODE = previous;
+      }
+    }
   });
 });
 

--- a/src/server/utils/security-headers.ts
+++ b/src/server/utils/security-headers.ts
@@ -1,5 +1,9 @@
 import type { BunRequest } from "bun";
+import { log } from "../services/logger";
+import { SITE_NAME } from "../services/seo";
 import { withCompression } from "./compression";
+import { render500 } from "./errors";
+import { maintenanceResponse } from "./maintenance";
 
 // Single source of truth for the security headers sent on every response —
 // HTML, JSON, redirects, static files, and errors alike. Applied centrally
@@ -101,6 +105,14 @@ export const withSecurityHeaders = (res: Response): Response => {
   if (!res.headers.has("Link")) {
     res.headers.set("Link", DISCOVERY_LINK_HEADER);
   }
+  // Sign every redirect with the software that issued it, so anyone tracing a
+  // redirect chain can see which layer to fix (spec: resilience/redirect-by).
+  // Gating on Location covers every redirect source — the `redirect()` helper,
+  // the trailing-slash 308, and the inline 303s in the auth/admin middleware —
+  // without each having to remember to set it.
+  if (res.headers.has("Location") && !res.headers.has("X-Redirect-By")) {
+    res.headers.set("X-Redirect-By", SITE_NAME);
+  }
   return res;
 };
 
@@ -118,16 +130,40 @@ export const finalizeResponse = async (
   return withSecurityHeaders(compressed);
 };
 
+// Run a response producer through the full request pipeline: honour maintenance
+// mode, catch any uncaught error as a styled 500 (never leaking a stack trace),
+// then `finalizeResponse`. Both the routed handlers (via `secureRoutes`) and the
+// `fetch` fallback go through this, so no path can bypass the guards or headers.
+export const handleGuarded = async <R extends Request>(
+  req: R,
+  produce: (req: R) => Response | Promise<Response>,
+): Promise<Response> => {
+  const maintenance = maintenanceResponse(req);
+  if (maintenance) return finalizeResponse(req, maintenance);
+
+  try {
+    return await finalizeResponse(req, await produce(req));
+  } catch (error) {
+    const { pathname } = new URL(req.url);
+    log.error(
+      "server",
+      `Unhandled error on ${req.method} ${pathname}: ${error}`,
+    );
+    return finalizeResponse(req, render500());
+  }
+};
+
 type RouteHandler = (req: BunRequest) => Response | Promise<Response>;
 
-// Wrap a Bun `routes` map so every handler's response runs through
-// `finalizeResponse` before it leaves the server.
+// Wrap a Bun `routes` map so every handler runs through the guarded pipeline
+// (maintenance mode, 500 fallback, compression, security headers) before its
+// response leaves the server.
 export const secureRoutes = <T extends Record<string, RouteHandler>>(
   routes: T,
 ): T => {
   const wrapped: Record<string, RouteHandler> = {};
   for (const [path, handler] of Object.entries(routes)) {
-    wrapped[path] = async (req) => finalizeResponse(req, await handler(req));
+    wrapped[path] = (req) => handleGuarded(req, handler);
   }
   return wrapped as T;
 };

--- a/src/server/utils/static-files.ts
+++ b/src/server/utils/static-files.ts
@@ -3,7 +3,7 @@
 // validator, and answers conditional requests with a 304. Fingerprinted bundles
 // take the immutable path in services/assets.ts instead.
 
-// public/ assets (favicons, og-image, manifest, cube.json) are not
+// public/ assets (favicons, og-image, cube.json) are not
 // fingerprinted, so they revalidate rather than caching forever: a short max-age
 // with stale-while-revalidate/stale-if-error for resilience under load or origin
 // errors.


### PR DESCRIPTION
Implements the **Resilience** section of [specification.website](https://specification.website), the next section in the ongoing spec audit (Foundations, SEO, Accessibility, Security, Performance, Privacy already done).

## What's in here

### Custom error pages — 404 / 500 (Required)
- New `ErrorLayout` — same header/nav/footer chrome as the site, but **ships zero client JS** (no importmap, Lottie, or main bundle) so error pages render instantly even when the app is degraded, and always `noindex`. Extracted a shared `SiteFooter` so the repo-specific links live in one place.
- `templates/error.tsx` + `utils/errors.tsx` render `render404()` / `render500()` / `render503()`.
- **404**: `fallback.ts` now returns the styled, navigable page instead of plain-text `"Not found"` (correct status, homepage link, no leaks).
- **500**: a new `handleGuarded()` wraps **both** the routed handlers and the fallback — it catches any uncaught error, logs it server-side, and returns the styled 500 with **no stack-trace / path leak**. A `Bun.serve` `error()` backstop also suppresses Bun's dev error page (which *does* leak).

### 503 maintenance (Recommended)
- `MAINTENANCE_MODE=true` serves a 503 with a `Retry-After` header (default 3600s, override via `MAINTENANCE_RETRY_AFTER`) for every request **except `/health`** (so the platform doesn't cycle the instance). Documented in `.env.example`.

### Web app manifest (Recommended)
- Made **dynamic** so the name is never stuck as "Billet": deleted the static file, added `buildWebManifest()` driven by `SITE_NAME` (+ `start_url`, `scope`, `display: standalone`, theme/bg colours, 192/512 icons, and a **maskable** icon), served at `/site.webmanifest` with `application/manifest+json`.
- **START_PROMPT.md** notes that the manifest and `X-Redirect-By` both follow `SITE_NAME` — renaming that one constant renames both.

### X-Redirect-By (Recommended)
- Stamped **centrally** in `withSecurityHeaders`: any response with a `Location` header gets `X-Redirect-By: <SITE_NAME>`. One line covers every redirect — the `redirect()` helper, the 308 trailing-slash, and the inline 303s in the auth/admin middleware.

### Graceful degradation (Recommended)
- Already passed (full SSR, real `<a>`/`<form action>`, the single projects-search island degrades to the server-rendered list). Reinforced by making the new error/maintenance pages zero-JS.

## Deferred (Optional / infra)
Service worker / offline (skipped by request); Deprecation/Sunset headers (no versioned endpoints yet); external synthetic monitoring, separate-host status page, and RUM/web-vitals (ops/infra — the `/health` liveness endpoint already exists).

## Testing
- `bun run check` clean; **321 tests pass** (added `errors.test.tsx`, `webmanifest.test.ts`, plus X-Redirect-By and `handleGuarded` cases; updated `fallback.test.ts`).
- Verified live in-browser: 404 (status + nav + CTA navigates home), 500, 503 (correctly drops nav/home button), and the manifest (`application/manifest+json`, name/short_name/start_url/maskable).

## How to test the error pages locally
- **404**: visit any nonexistent URL, e.g. `/nope`.
- **503**: set `MAINTENANCE_MODE=true` in `.env`, restart — every page 503s except `/health`; unset to lift.
- **500**: temporarily `throw new Error("preview 500")` in a controller (e.g. `home.index()`), hit the page, remove it. The real error logs to the terminal, never to the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)